### PR TITLE
Add version to cluster common type

### DIFF
--- a/pkg/apis/provider/v1alpha1/common_types.go
+++ b/pkg/apis/provider/v1alpha1/common_types.go
@@ -13,6 +13,7 @@ type Cluster struct {
 	Kubernetes ClusterKubernetes `json:"kubernetes" yaml:"kubernetes"`
 	Masters    []ClusterNode     `json:"masters" yaml:"masters"`
 	Vault      ClusterVault      `json:"vault" yaml:"vault"`
+	Version    string            `json:"version" yaml:"version"`
 	Workers    []ClusterNode     `json:"workers" yaml:"workers"`
 }
 


### PR DESCRIPTION
Adds version to the cluster common type. This is for AWS to determine if clusters need the locked down config. I ran `scripts/gen.sh` but no changes were made.