### PR TITLE
bump dependencies to kubernetes-1.8.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -172,26 +172,26 @@
 [[projects]]
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/apis/apiextensions","pkg/apis/apiextensions/v1beta1"]
-  revision = "e509bb64fe1116e12a32273a2032426aa1a5fd26"
-  version = "kubernetes-1.8.2"
+  revision = "996a70a27a0dcf53642ca52601b9107cb2ad810a"
+  version = "kubernetes-1.8.4"
 
 [[projects]]
-  branch = "release-1.8"
   name = "k8s.io/apimachinery"
   packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
-  revision = "019ae5ada31de202164b118aee88ee2d14075c31"
+  revision = "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+  version = "kubernetes-1.8.3"
 
 [[projects]]
   name = "k8s.io/client-go"
   packages = ["discovery","discovery/fake","kubernetes/scheme","pkg/version","rest","rest/watch","testing","tools/clientcmd/api","tools/metrics","transport","util/cert","util/flowcontrol","util/integer"]
-  revision = "35ccd4336052e7d73018b1382413534936f34eee"
-  version = "kubernetes-1.8.2"
+  revision = "1b75876d45719a84085528ee621939b0c68a4b85"
+  version = "kubernetes-1.8.5"
 
 [[projects]]
   name = "k8s.io/code-generator"
   packages = ["cmd/client-gen","cmd/client-gen/args","cmd/client-gen/generators","cmd/client-gen/generators/fake","cmd/client-gen/generators/scheme","cmd/client-gen/generators/util","cmd/client-gen/path","cmd/client-gen/types"]
-  revision = "1f9d929a2d32f787df8d29f987f31aff1501c0f8"
-  version = "kubernetes-1.8.2"
+  revision = "25fd8c8ddbf75b223882df4479f8b8e615da05ae"
+  version = "kubernetes-1.8.5"
 
 [[projects]]
   branch = "master"
@@ -208,6 +208,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b1e4e080159551c8709f26fd5999a8a782d841c05b7c99271653dedf39f8e3cf"
+  inputs-digest = "b1c78f4e8aff6b6efd8d2e51c638ae1d22f1994c620a933c9ccec6c6489695fc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,20 +26,20 @@ required = [
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.8.2"
+  version = "kubernetes-1.8.5"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.8.2"
+  version = "kubernetes-1.8.5"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.8.2"
+  version = "kubernetes-1.8.5"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.8.2"
+  version = "kubernetes-1.8.5"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "kubernetes-1.8.2"
+  version = "kubernetes-1.8.5"

--- a/vendor/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/apiextensions-apiserver",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
@@ -612,935 +612,935 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/testing",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/testing/fuzzer",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/testing/roundtrip",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation/path",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/proxy",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/uuid",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/initializer",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/install",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1beta1",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/validation",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit/policy",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticator",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/group",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/union",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/x509",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/user",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizer",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/union",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/discovery",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/filters",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/metrics",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/openapi",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/request",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/features",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic/registry",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/rest",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/filters",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/healthz",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/httplog",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/mux",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/options",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/storage",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/errors",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/util",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3/preflight",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/names",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/value",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flag",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flushwriter",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/logs",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/webhook",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/wsstream",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/log",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Rev": "9707c008294d447053c0e2737c256ee23f99e5b4"
+			"Rev": "2279c12eff8d4d1dc65a104dac36483c1b59ff54"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/dynamic",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta2",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v2beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v2alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/internalinterfaces",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta2",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v2beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v2alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/certificates/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/core/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/extensions/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/networking/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/policy/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/scheduling/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/settings/v1alpha1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1beta1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/testing",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/pager",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/reference",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
-			"Rev": "1fb83015bea362f028381bc0fcfb2a4e3eb7390b"
+			"Rev": "584b13d350032197c1d1ab5507ab705dcbdf59d1"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/BUILD
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -21,7 +21,6 @@ package internalversion
 import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*apiextensions.CustomResourceDefinition, error) {
-	key := &apiextensions.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/BUILD
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
-	key := &v1beta1.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/apiextensions-apiserver/test/integration/BUILD
+++ b/vendor/k8s.io/apiextensions-apiserver/test/integration/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/vendor/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/vendor/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -398,6 +399,69 @@ func TestPreserveInt(t *testing.T) {
 	num2 := num["num2"].(int64)
 	if num1 != 9223372036854775807 || num2 != 1000000 {
 		t.Errorf("Expected %v, got %v, %v", `9223372036854775807, 1000000`, num1, num2)
+	}
+}
+
+func TestPatch(t *testing.T) {
+	stopCh, apiExtensionClient, clientPool, err := testserver.StartDefaultServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close(stopCh)
+
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := "not-the-default"
+	noxuNamespacedResourceClient := noxuVersionClient.Resource(&metav1.APIResource{
+		Name:       noxuDefinition.Spec.Names.Plural,
+		Namespaced: true,
+	}, ns)
+
+	noxuInstanceToCreate := testserver.NewNoxuInstance(ns, "foo")
+	createdNoxuInstance, err := noxuNamespacedResourceClient.Create(noxuInstanceToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patch := []byte(`{"num": {"num2":999}}`)
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// a patch with no change
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// an empty patch
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	originalJSON, err := runtime.Encode(unstructured.UnstructuredJSONScheme, createdNoxuInstance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gottenNoxuInstance, err := runtime.Decode(unstructured.UnstructuredJSONScheme, originalJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check if int is preserved.
+	unstructuredObj := gottenNoxuInstance.(*unstructured.Unstructured).Object
+	num := unstructuredObj["num"].(map[string]interface{})
+	num1 := num["num1"].(int64)
+	num2 := num["num2"].(int64)
+	if num1 != 9223372036854775807 || num2 != 999 {
+		t.Errorf("Expected %v, got %v, %v", `9223372036854775807, 999`, num1, num2)
 	}
 }
 

--- a/vendor/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/vendor/k8s.io/apimachinery/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/apimachinery",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."

--- a/vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -110,7 +110,7 @@ func (s *SpdyRoundTripper) Dial(req *http.Request) (net.Conn, error) {
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 	proxier := s.proxier
 	if proxier == nil {
-		proxier = http.ProxyFromEnvironment
+		proxier = utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 	}
 	proxyURL, err := proxier(req)
 	if err != nil {

--- a/vendor/k8s.io/client-go/Godeps/Godeps.json
+++ b/vendor/k8s.io/client-go/Godeps/Godeps.json
@@ -1,678 +1,670 @@
 {
-  "ImportPath": "k8s.io/client-go",
-  "GoVersion": "go1.8",
-  "GodepVersion": "v79",
-  "Packages": [
-    "./..."
-  ],
-  "Deps": [
-    {
-      "ImportPath": "cloud.google.com/go/compute/metadata",
-      "Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
-    },
-    {
-      "ImportPath": "cloud.google.com/go/internal",
-      "Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
-    },
-    {
-      "ImportPath": "github.com/Azure/go-autorest/autorest",
-      "Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-    },
-    {
-      "ImportPath": "github.com/Azure/go-autorest/autorest/adal",
-      "Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-    },
-    {
-      "ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-      "Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-    },
-    {
-      "ImportPath": "github.com/Azure/go-autorest/autorest/date",
-      "Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-    },
-    {
-      "ImportPath": "github.com/PuerkitoBio/purell",
-      "Rev": "8a290539e2e8629dbc4e6bad948158f790ec31f4"
-    },
-    {
-      "ImportPath": "github.com/PuerkitoBio/urlesc",
-      "Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
-    },
-    {
-      "ImportPath": "github.com/coreos/go-oidc/http",
-      "Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
-    },
-    {
-      "ImportPath": "github.com/coreos/go-oidc/jose",
-      "Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
-    },
-    {
-      "ImportPath": "github.com/coreos/go-oidc/key",
-      "Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
-    },
-    {
-      "ImportPath": "github.com/coreos/go-oidc/oauth2",
-      "Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
-    },
-    {
-      "ImportPath": "github.com/coreos/go-oidc/oidc",
-      "Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
-    },
-    {
-      "ImportPath": "github.com/coreos/pkg/health",
-      "Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
-    },
-    {
-      "ImportPath": "github.com/coreos/pkg/httputil",
-      "Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
-    },
-    {
-      "ImportPath": "github.com/coreos/pkg/timeutil",
-      "Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
-    },
-    {
-      "ImportPath": "github.com/davecgh/go-spew/spew",
-      "Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
-    },
-    {
-      "ImportPath": "github.com/dgrijalva/jwt-go",
-      "Rev": "01aeca54ebda6e0fbfafd0a524d234159c05ec20"
-    },
-    {
-      "ImportPath": "github.com/docker/spdystream",
-      "Rev": "449fdfce4d962303d702fec724ef0ad181c92528"
-    },
-    {
-      "ImportPath": "github.com/docker/spdystream/spdy",
-      "Rev": "449fdfce4d962303d702fec724ef0ad181c92528"
-    },
-    {
-      "ImportPath": "github.com/emicklei/go-restful",
-      "Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
-    },
-    {
-      "ImportPath": "github.com/emicklei/go-restful-swagger12",
-      "Rev": "dcef7f55730566d41eae5db10e7d6981829720f6"
-    },
-    {
-      "ImportPath": "github.com/emicklei/go-restful/log",
-      "Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
-    },
-    {
-      "ImportPath": "github.com/ghodss/yaml",
-      "Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
-    },
-    {
-      "ImportPath": "github.com/go-openapi/jsonpointer",
-      "Rev": "46af16f9f7b149af66e5d1bd010e3574dc06de98"
-    },
-    {
-      "ImportPath": "github.com/go-openapi/jsonreference",
-      "Rev": "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
-    },
-    {
-      "ImportPath": "github.com/go-openapi/spec",
-      "Rev": "6aced65f8501fe1217321abf0749d354824ba2ff"
-    },
-    {
-      "ImportPath": "github.com/go-openapi/swag",
-      "Rev": "1d0bd113de87027671077d3c71eb3ac5d7dbba72"
-    },
-    {
-      "ImportPath": "github.com/gogo/protobuf/proto",
-      "Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
-    },
-    {
-      "ImportPath": "github.com/gogo/protobuf/sortkeys",
-      "Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
-    },
-    {
-      "ImportPath": "github.com/golang/glog",
-      "Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
-    },
-    {
-      "ImportPath": "github.com/golang/groupcache/lru",
-      "Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
-    },
-    {
-      "ImportPath": "github.com/golang/protobuf/proto",
-      "Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-    },
-    {
-      "ImportPath": "github.com/golang/protobuf/ptypes",
-      "Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-    },
-    {
-      "ImportPath": "github.com/golang/protobuf/ptypes/any",
-      "Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-    },
-    {
-      "ImportPath": "github.com/golang/protobuf/ptypes/duration",
-      "Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-    },
-    {
-      "ImportPath": "github.com/golang/protobuf/ptypes/timestamp",
-      "Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-    },
-    {
-      "ImportPath": "github.com/google/btree",
-      "Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
-    },
-    {
-      "ImportPath": "github.com/google/gofuzz",
-      "Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
-    },
-    {
-      "ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
-      "Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-    },
-    {
-      "ImportPath": "github.com/googleapis/gnostic/compiler",
-      "Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-    },
-    {
-      "ImportPath": "github.com/googleapis/gnostic/extensions",
-      "Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/openstack",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gophercloud/gophercloud/pagination",
-      "Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
-    },
-    {
-      "ImportPath": "github.com/gregjones/httpcache",
-      "Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-    },
-    {
-      "ImportPath": "github.com/gregjones/httpcache/diskcache",
-      "Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-    },
-    {
-      "ImportPath": "github.com/hashicorp/golang-lru",
-      "Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
-    },
-    {
-      "ImportPath": "github.com/hashicorp/golang-lru/simplelru",
-      "Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
-    },
-    {
-      "ImportPath": "github.com/howeyc/gopass",
-      "Rev": "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
-    },
-    {
-      "ImportPath": "github.com/imdario/mergo",
-      "Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
-    },
-    {
-      "ImportPath": "github.com/jonboulle/clockwork",
-      "Rev": "72f9bd7c4e0c2a40055ab3d0f09654f730cce982"
-    },
-    {
-      "ImportPath": "github.com/json-iterator/go",
-      "Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
-    },
-    {
-      "ImportPath": "github.com/juju/ratelimit",
-      "Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
-    },
-    {
-      "ImportPath": "github.com/mailru/easyjson/buffer",
-      "Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
-    },
-    {
-      "ImportPath": "github.com/mailru/easyjson/jlexer",
-      "Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
-    },
-    {
-      "ImportPath": "github.com/mailru/easyjson/jwriter",
-      "Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
-    },
-    {
-      "ImportPath": "github.com/peterbourgon/diskv",
-      "Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
-    },
-    {
-      "ImportPath": "github.com/pmezard/go-difflib/difflib",
-      "Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
-    },
-    {
-      "ImportPath": "github.com/spf13/pflag",
-      "Rev": "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
-    },
-    {
-      "ImportPath": "github.com/stretchr/testify/assert",
-      "Rev": "f6abca593680b2315d2075e0f5e2a9751e3f431a"
-    },
-    {
-      "ImportPath": "golang.org/x/crypto/ssh/terminal",
-      "Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
-    },
-    {
-      "ImportPath": "golang.org/x/net/context",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/net/context/ctxhttp",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/net/http2",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/net/http2/hpack",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/net/idna",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/net/lex/httplex",
-      "Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
-    },
-    {
-      "ImportPath": "golang.org/x/oauth2",
-      "Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-    },
-    {
-      "ImportPath": "golang.org/x/oauth2/google",
-      "Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-    },
-    {
-      "ImportPath": "golang.org/x/oauth2/internal",
-      "Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-    },
-    {
-      "ImportPath": "golang.org/x/oauth2/jws",
-      "Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-    },
-    {
-      "ImportPath": "golang.org/x/oauth2/jwt",
-      "Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-    },
-    {
-      "ImportPath": "golang.org/x/sys/unix",
-      "Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
-    },
-    {
-      "ImportPath": "golang.org/x/sys/windows",
-      "Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
-    },
-    {
-      "ImportPath": "golang.org/x/text/cases",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/internal",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/internal/tag",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/language",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/runes",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/secure/bidirule",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/secure/precis",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/transform",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/unicode/bidi",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/unicode/norm",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "golang.org/x/text/width",
-      "Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-    },
-    {
-      "ImportPath": "gopkg.in/inf.v0",
-      "Rev": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
-    },
-    {
-      "ImportPath": "gopkg.in/yaml.v2",
-      "Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
-    },
-    {
-      "ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/apps/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/apps/v1beta2",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/authentication/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/authentication/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/authorization/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/authorization/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/autoscaling/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/autoscaling/v2beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/batch/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/batch/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/batch/v2alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/certificates/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/core/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/extensions/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/networking/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/policy/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/rbac/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/rbac/v1alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/rbac/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/scheduling/v1alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/settings/v1alpha1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/storage/v1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/api/storage/v1beta1",
-      "Rev": "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apimachinery",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apimachinery/registered",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/conversion",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/fields",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/labels",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/selection",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/types",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/json",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/net",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/version",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/pkg/watch",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-      "Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-    },
-    {
-      "ImportPath": "k8s.io/kube-openapi/pkg/common",
-      "Rev": "868f2f29720b192240e18284659231b440f9cda5"
-    }
-  ]
+	"ImportPath": "k8s.io/client-go",
+	"GoVersion": "go1.9",
+	"GodepVersion": "v79",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "cloud.google.com/go/compute/metadata",
+			"Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
+		},
+		{
+			"ImportPath": "cloud.google.com/go/internal",
+			"Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
+		},
+		{
+			"ImportPath": "github.com/Azure/go-autorest/autorest",
+			"Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
+		},
+		{
+			"ImportPath": "github.com/Azure/go-autorest/autorest/adal",
+			"Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
+		},
+		{
+			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
+			"Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
+		},
+		{
+			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
+			"Rev": "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
+		},
+		{
+			"ImportPath": "github.com/PuerkitoBio/purell",
+			"Rev": "8a290539e2e8629dbc4e6bad948158f790ec31f4"
+		},
+		{
+			"ImportPath": "github.com/PuerkitoBio/urlesc",
+			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/http",
+			"Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/jose",
+			"Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/key",
+			"Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/oauth2",
+			"Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/oidc",
+			"Rev": "a4973d9a4225417aecf5d450a9522f00c1f7130f"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/health",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/httputil",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/timeutil",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
+			"ImportPath": "github.com/davecgh/go-spew/spew",
+			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
+		},
+		{
+			"ImportPath": "github.com/dgrijalva/jwt-go",
+			"Rev": "01aeca54ebda6e0fbfafd0a524d234159c05ec20"
+		},
+		{
+			"ImportPath": "github.com/docker/spdystream",
+			"Rev": "449fdfce4d962303d702fec724ef0ad181c92528"
+		},
+		{
+			"ImportPath": "github.com/docker/spdystream/spdy",
+			"Rev": "449fdfce4d962303d702fec724ef0ad181c92528"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful-swagger12",
+			"Rev": "dcef7f55730566d41eae5db10e7d6981829720f6"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful/log",
+			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonpointer",
+			"Rev": "46af16f9f7b149af66e5d1bd010e3574dc06de98"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/jsonreference",
+			"Rev": "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/spec",
+			"Rev": "6aced65f8501fe1217321abf0749d354824ba2ff"
+		},
+		{
+			"ImportPath": "github.com/go-openapi/swag",
+			"Rev": "1d0bd113de87027671077d3c71eb3ac5d7dbba72"
+		},
+		{
+			"ImportPath": "github.com/gogo/protobuf/proto",
+			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+		},
+		{
+			"ImportPath": "github.com/gogo/protobuf/sortkeys",
+			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+		},
+		{
+			"ImportPath": "github.com/golang/glog",
+			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes",
+			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/any",
+			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/duration",
+			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/timestamp",
+			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
+		},
+		{
+			"ImportPath": "github.com/google/btree",
+			"Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
+		},
+		{
+			"ImportPath": "github.com/google/gofuzz",
+			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/compiler",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/googleapis/gnostic/extensions",
+			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
+			"Rev": "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+		},
+		{
+			"ImportPath": "github.com/gregjones/httpcache",
+			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
+		},
+		{
+			"ImportPath": "github.com/gregjones/httpcache/diskcache",
+			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/howeyc/gopass",
+			"Rev": "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+		},
+		{
+			"ImportPath": "github.com/imdario/mergo",
+			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
+		},
+		{
+			"ImportPath": "github.com/jonboulle/clockwork",
+			"Rev": "72f9bd7c4e0c2a40055ab3d0f09654f730cce982"
+		},
+		{
+			"ImportPath": "github.com/json-iterator/go",
+			"Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
+		},
+		{
+			"ImportPath": "github.com/juju/ratelimit",
+			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/buffer",
+			"Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jlexer",
+			"Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
+		},
+		{
+			"ImportPath": "github.com/mailru/easyjson/jwriter",
+			"Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
+		},
+		{
+			"ImportPath": "github.com/peterbourgon/diskv",
+			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
+		},
+		{
+			"ImportPath": "github.com/pmezard/go-difflib/difflib",
+			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify/assert",
+			"Rev": "f6abca593680b2315d2075e0f5e2a9751e3f431a"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context/ctxhttp",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2/hpack",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/idna",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/google",
+			"Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/internal",
+			"Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jws",
+			"Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jwt",
+			"Rev": "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/windows",
+			"Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
+		},
+		{
+			"ImportPath": "golang.org/x/text/cases",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/internal",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/internal/tag",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/language",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/runes",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/secure/bidirule",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/secure/precis",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/transform",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/unicode/bidi",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/unicode/norm",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/text/width",
+			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "gopkg.in/inf.v0",
+			"Rev": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
+		},
+		{
+			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/apps/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/apps/v1beta2",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/authentication/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/authentication/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/authorization/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/authorization/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/autoscaling/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/batch/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/batch/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/batch/v2alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/certificates/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/core/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/extensions/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/networking/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/policy/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/rbac/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/rbac/v1alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/rbac/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/settings/v1alpha1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/storage/v1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/api/storage/v1beta1",
+			"Rev": "f63f838f2e6d362a1fd4a710ae13f603e4b51ea9"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/fields",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/labels",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/selection",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/types",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/version",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/watch",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
+			"Rev": "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
+		},
+		{
+			"ImportPath": "k8s.io/kube-openapi/pkg/common",
+			"Rev": "868f2f29720b192240e18284659231b440f9cda5"
+		}
+	]
 }

--- a/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/BUILD
+++ b/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector
 
 // Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 func (s *externalAdmissionHookConfigurationLister) Get(name string) (*v1alpha1.ExternalAdmissionHookConfiguration, error) {
-	key := &v1alpha1.ExternalAdmissionHookConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/vendor/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the InitializerConfiguration from the index for a given name.
 func (s *initializerConfigurationLister) Get(name string) (*v1alpha1.InitializerConfiguration, error) {
-	key := &v1alpha1.InitializerConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authentication/v1/BUILD
+++ b/vendor/k8s.io/client-go/listers/authentication/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/authentication/v1/tokenreview.go
+++ b/vendor/k8s.io/client-go/listers/authentication/v1/tokenreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1.TokenRevie
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1.TokenReview, error) {
-	key := &v1.TokenReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authentication/v1beta1/BUILD
+++ b/vendor/k8s.io/client-go/listers/authentication/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authentication/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
+++ b/vendor/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1beta1.Token
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1beta1.TokenReview, error) {
-	key := &v1beta1.TokenReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1/BUILD
+++ b/vendor/k8s.io/client-go/listers/authorization/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1.SelfSubjectAccessReview, error) {
-	key := &v1.SelfSubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1/selfsubjectrulesreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1/selfsubjectrulesreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectRulesReviewLister) List(selector labels.Selector) (ret []*v1
 
 // Get retrieves the SelfSubjectRulesReview from the index for a given name.
 func (s *selfSubjectRulesReviewLister) Get(name string) (*v1.SelfSubjectRulesReview, error) {
-	key := &v1.SelfSubjectRulesReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1.Su
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1.SubjectAccessReview, error) {
-	key := &v1.SubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1beta1/BUILD
+++ b/vendor/k8s.io/client-go/listers/authorization/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1beta1.SelfSubjectAccessReview, error) {
-	key := &v1beta1.SelfSubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectrulesreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectRulesReviewLister) List(selector labels.Selector) (ret []*v1
 
 // Get retrieves the SelfSubjectRulesReview from the index for a given name.
 func (s *selfSubjectRulesReviewLister) Get(name string) (*v1beta1.SelfSubjectRulesReview, error) {
-	key := &v1beta1.SelfSubjectRulesReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
+++ b/vendor/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1bet
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1beta1.SubjectAccessReview, error) {
-	key := &v1beta1.SubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/certificates/v1beta1/BUILD
+++ b/vendor/k8s.io/client-go/listers/certificates/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/vendor/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.CertificateSigningRequest, error) {
-	key := &v1beta1.CertificateSigningRequest{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/core/v1/BUILD
+++ b/vendor/k8s.io/client-go/listers/core/v1/BUILD
@@ -32,7 +32,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/core/v1/componentstatus.go
+++ b/vendor/k8s.io/client-go/listers/core/v1/componentstatus.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *componentStatusLister) List(selector labels.Selector) (ret []*v1.Compon
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
-	key := &v1.ComponentStatus{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/core/v1/namespace.go
+++ b/vendor/k8s.io/client-go/listers/core/v1/namespace.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *namespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, e
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
-	key := &v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/core/v1/node.go
+++ b/vendor/k8s.io/client-go/listers/core/v1/node.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *nodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) 
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*v1.Node, error) {
-	key := &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/core/v1/persistentvolume.go
+++ b/vendor/k8s.io/client-go/listers/core/v1/persistentvolume.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*v1.Persi
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) {
-	key := &v1.PersistentVolume{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/vendor/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, error) {
-	key := &v1beta1.PodSecurityPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/vendor/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ThirdPartyResource from the index for a given name.
 func (s *thirdPartyResourceLister) Get(name string) (*v1beta1.ThirdPartyResource, error) {
-	key := &v1beta1.ThirdPartyResource{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/imagepolicy/v1alpha1/BUILD
+++ b/vendor/k8s.io/client-go/listers/imagepolicy/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/imagepolicy/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/vendor/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *imageReviewLister) List(selector labels.Selector) (ret []*v1alpha1.Imag
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*v1alpha1.ImageReview, error) {
-	key := &v1alpha1.ImageReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1/BUILD
+++ b/vendor/k8s.io/client-go/listers/rbac/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/rbac/v1/clusterrole.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1/clusterrole.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRol
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1.ClusterRole, error) {
-	key := &v1.ClusterRole{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.Clu
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1.ClusterRoleBinding, error) {
-	key := &v1.ClusterRoleBinding{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
+++ b/vendor/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1alpha1.Clus
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
-	key := &v1alpha1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1alph
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBinding, error) {
-	key := &v1alpha1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1beta1/BUILD
+++ b/vendor/k8s.io/client-go/listers/rbac/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1beta1.Clust
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
-	key := &v1beta1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding, error) {
-	key := &v1beta1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/scheduling/v1alpha1/BUILD
+++ b/vendor/k8s.io/client-go/listers/scheduling/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/scheduling/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
+++ b/vendor/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1alpha1.Pr
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*v1alpha1.PriorityClass, error) {
-	key := &v1alpha1.PriorityClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/storage/v1/BUILD
+++ b/vendor/k8s.io/client-go/listers/storage/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/storage/v1/storageclass.go
+++ b/vendor/k8s.io/client-go/listers/storage/v1/storageclass.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1.StorageCl
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
-	key := &v1.StorageClass{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/listers/storage/v1beta1/BUILD
+++ b/vendor/k8s.io/client-go/listers/storage/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/vendor/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.Stor
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
-	key := &v1beta1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -39,11 +39,11 @@ var (
 	// them irrelevant. (Next we'll take it out, which may muck with
 	// scripts consuming the kubectl version output - but most of
 	// these should be looking at gitVersion already anyways.)
-	gitMajor string = "1" // major version, always numeric
-	gitMinor string = "8" // minor version, numeric possibly followed by "+"
+	gitMajor = "1"  // major version, always numeric
+	gitMinor = "8+" // minor version, numeric possibly followed by "+"
 
 	// semantic version, derived by build scripts (see
-	// https://github.com/kubernetes/kubernetes/blob/master/docs/design/versioning.md
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md
 	// for a detailed discussion of this field)
 	//
 	// TODO: This field is still called "gitVersion" for legacy
@@ -51,9 +51,13 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.8.2+$Format:%h$"
-	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 
-	buildDate string = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
+	// companion .gitattributes file containing 'export-subst' in this same
+	// directory.  See also https://git-scm.com/docs/gitattributes
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )

--- a/vendor/k8s.io/client-go/rest/fake/BUILD
+++ b/vendor/k8s.io/client-go/rest/fake/BUILD
@@ -9,7 +9,6 @@ go_library(
     name = "go_default_library",
     srcs = ["fake.go"],
     deps = [
-        "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/vendor/k8s.io/client-go/rest/fake/fake.go
+++ b/vendor/k8s.io/client-go/rest/fake/fake.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,8 +45,7 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 type RESTClient struct {
 	Client               *http.Client
 	NegotiatedSerializer runtime.NegotiatedSerializer
-	GroupName            string
-	APIRegistry          *registered.APIRegistrationManager
+	GroupVersion         schema.GroupVersion
 	VersionedAPIPath     string
 
 	Req  *http.Request
@@ -80,7 +78,7 @@ func (c *RESTClient) Verb(verb string) *restclient.Request {
 }
 
 func (c *RESTClient) APIVersion() schema.GroupVersion {
-	return c.APIRegistry.GroupOrDie("").GroupVersion
+	return c.GroupVersion
 }
 
 func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
@@ -89,22 +87,20 @@ func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
 
 func (c *RESTClient) request(verb string) *restclient.Request {
 	config := restclient.ContentConfig{
-		ContentType: runtime.ContentTypeJSON,
-		// TODO this was hardcoded before, but it doesn't look right
-		GroupVersion:         &c.APIRegistry.GroupOrDie("").GroupVersion,
+		ContentType:          runtime.ContentTypeJSON,
+		GroupVersion:         &c.GroupVersion,
 		NegotiatedSerializer: c.NegotiatedSerializer,
 	}
 
 	ns := c.NegotiatedSerializer
 	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	internalVersion := schema.GroupVersion{
-		Group:   c.APIRegistry.GroupOrDie(c.GroupName).GroupVersion.Group,
+		Group:   c.GroupVersion.Group,
 		Version: runtime.APIVersionInternal,
 	}
-	internalVersion.Version = runtime.APIVersionInternal
 	serializers := restclient.Serializers{
 		// TODO this was hardcoded before, but it doesn't look right
-		Encoder: ns.EncoderForVersion(info.Serializer, c.APIRegistry.GroupOrDie("").GroupVersion),
+		Encoder: ns.EncoderForVersion(info.Serializer, c.GroupVersion),
 		Decoder: ns.DecoderToVersion(info.Serializer, internalVersion),
 	}
 	if info.StreamSerializer != nil {

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -109,7 +109,7 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	r := &Reflector{
 		name: name,
 		// we need this to be unique per process (some names are still the same)but obvious who it belongs to
-		metrics:       newReflectorMetrics(makeValidPromethusMetricName(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
+		metrics:       newReflectorMetrics(makeValidPromethusMetricLabel(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
 		listerWatcher: lw,
 		store:         store,
 		expectedType:  reflect.TypeOf(expectedType),
@@ -120,9 +120,9 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	return r
 }
 
-func makeValidPromethusMetricName(in string) string {
+func makeValidPromethusMetricLabel(in string) string {
 	// this isn't perfect, but it removes our common characters
-	return strings.NewReplacer("/", "_", ".", "_", "-", "_").Replace(in)
+	return strings.NewReplacer("/", "_", ".", "_", "-", "_", ":", "_").Replace(in)
 }
 
 // internalPackages are packages that ignored when creating a default reflector name. These packages are in the common

--- a/vendor/k8s.io/client-go/transport/cache.go
+++ b/vendor/k8s.io/client-go/transport/cache.go
@@ -88,5 +88,5 @@ func tlsConfigKey(c *Config) (string, error) {
 		return "", err
 	}
 	// Only include the things that actually affect the tls.Config
-	return fmt.Sprintf("%v/%x/%x/%x", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData), nil
+	return fmt.Sprintf("%v/%x/%x/%x/%v", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData, c.TLS.ServerName), nil
 }

--- a/vendor/k8s.io/client-go/transport/cache_test.go
+++ b/vendor/k8s.io/client-go/transport/cache_test.go
@@ -62,6 +62,20 @@ func TestTLSConfigKey(t *testing.T) {
 				KeyData:  []byte{1},
 			},
 		},
+		"cert 1, key 1, servername 1": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "1",
+			},
+		},
+		"cert 1, key 1, servername 2": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "2",
+			},
+		},
 		"cert 1, key 2": {
 			TLS: TLSConfig{
 				CertData: []byte{1},

--- a/vendor/k8s.io/code-generator/Godeps/Godeps.json
+++ b/vendor/k8s.io/code-generator/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/code-generator",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."

--- a/vendor/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/vendor/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -131,6 +131,10 @@ type conversionFuncMap map[conversionPair]*types.Type
 
 // Returns all manually-defined conversion functions in the package.
 func getManualConversionFunctions(context *generator.Context, pkg *types.Package, manualMap conversionFuncMap) {
+	if pkg == nil {
+		glog.Warningf("Skipping nil package passed to getManualConversionFunctions")
+		return
+	}
 	glog.V(5).Infof("Scanning for conversion functions in %v", pkg.Name)
 
 	scopeName := types.Ref(conversionPackagePath, "Scope").Name

--- a/vendor/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/vendor/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -322,8 +322,7 @@ func (s *$.type|private$Lister) $.type|publicPlural$(namespace string) $.type|pu
 var typeLister_NonNamespacedGet = `
 // Get retrieves the $.type|public$ from the index for a given name.
 func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
-  key := &$.type|raw${ObjectMeta: $.objectMeta|raw${Name: name}}
-  obj, exists, err := s.indexer.Get(key)
+  obj, exists, err := s.indexer.GetByKey(name)
   if err != nil {
     return nil, err
   }


### PR DESCRIPTION
This fixes issue with glide for aws-operator. There are some broken dependencies, when apiextensions has kubernetes-1.8.2 branch.
 

CI already red in `clientset` branch :/