### PR TITLE
provider/v1alpha1: remove Azure node SSH config

### DIFF
--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -107,10 +107,6 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 }
 
 type AzureConfigSpecAzureNode struct {
-	// AdminUsername is the vm administrator username
-	AdminUsername string `json:"adminUsername" yaml:"adminUsername"`
-	//  AdminSSHKeyData is the vm administrator ssh public key
-	AdminSSHKeyData string `json:"adminSSHKeyData" yaml:"adminSSHKeyData"`
 	// VMSize is the master vm size (e.g. Standard_A1)
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 }


### PR DESCRIPTION
In the operator it is reused from Cluster part of the object.
See: https://github.com/giantswarm/azure-operator/pull/97.