### PR TITLE
added deprecation comments to KVMConfig

### DIFF
--- a/pkg/apis/provider/v1alpha1/kvm_types.go
+++ b/pkg/apis/provider/v1alpha1/kvm_types.go
@@ -64,8 +64,9 @@ type KVMConfigSpecKVM struct {
 	K8sKVM          KVMConfigSpecKVMK8sKVM          `json:"k8sKVM" yaml:"k8sKVM"`
 	Masters         []KVMConfigSpecKVMNode          `json:"masters" yaml:"masters"`
 	Network         KVMConfigSpecKVMNetwork         `json:"network" yaml:"network"`
-	NodeController  KVMConfigSpecKVMNodeController  `json:"nodeController" yaml:"nodeController"`
-	Workers         []KVMConfigSpecKVMNode          `json:"workers" yaml:"workers"`
+	// NOTE THIS IS DEPRECATED
+	NodeController KVMConfigSpecKVMNodeController `json:"nodeController" yaml:"nodeController"`
+	Workers        []KVMConfigSpecKVMNode         `json:"workers" yaml:"workers"`
 }
 
 type KVMConfigSpecKVMEndpointUpdater struct {
@@ -99,10 +100,12 @@ type KVMConfigSpecKVMNetworkFlannel struct {
 	VNI int `json:"vni" yaml:"vni"`
 }
 
+// NOTE THIS IS DEPRECATED
 type KVMConfigSpecKVMNodeController struct {
 	Docker KVMConfigSpecKVMNodeControllerDocker `json:"docker" yaml:"docker"`
 }
 
+// NOTE THIS IS DEPRECATED
 type KVMConfigSpecKVMNodeControllerDocker struct {
 	Image string `json:"image" yaml:"image"`
 }


### PR DESCRIPTION
I want to get rid of certain settings in the custom objects. Here we deprecate the Docker image of the KVM node-controller. In the future we can then remove all related code as soon as no existing guest cluster makes use of this anymore. See also https://github.com/giantswarm/kubernetesd/pull/359 and https://github.com/giantswarm/kvm-operator/pull/366. 