### PR TITLE
Add azure host cluster network name

### DIFF
--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -95,6 +95,8 @@ type AzureConfigSpecAzureHostCluster struct {
 	// ResourceGroup is the resource group name of the host cluster. It is
 	// used to determine DNS hosted zone to put NS records in.
 	ResourceGroup string `json:"resourceGroup" yaml:"resourceGroup"`
+	// VirtualNetwork is the name of the host cluster virtual network.
+	VirtualNetwork string `json:"virtualNetwork" yaml:"virtualNetwork"`
 }
 
 type AzureConfigSpecAzureVirtualNetwork struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/azure-operator/issues/115

Provide host cluster virtual network's name in AzureConfig