### PR TITLE
Improve naming: CommonDomain -> DNSZone

### DIFF
--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 type ClusterGuestConfig struct {
-	CommonDomain   string                            `json:"commonDomain" yaml:"commonDomain"`
+	DNSZone        string                            `json:"dnsZone" yaml:"dnsZone"`
 	ID             string                            `json:"id" yaml:"id"`
 	Name           string                            `json:"name,omitempty" yaml:"name,omitempty"`
 	Owner          string                            `json:"owner,omitempty" yaml:"owner,omitempty"`

--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -1,6 +1,10 @@
 package v1alpha1
 
 type ClusterGuestConfig struct {
+	// DNSZone for guest cluster is supplemented with host prefixes for
+	// specific services such as Kubernetes API or Etcd. In general this DNS
+	// Zone should start with `k8s` like for example
+	// `k8s.cluster.example.com.`.
 	DNSZone        string                            `json:"dnsZone" yaml:"dnsZone"`
 	ID             string                            `json:"id" yaml:"id"`
 	Name           string                            `json:"name,omitempty" yaml:"name,omitempty"`


### PR DESCRIPTION
As suggested in previous [PR](https://github.com/giantswarm/apiextensions/pull/59), DNSZone communicates purpose of this field
better than CommonDomain.