### PR TITLE
helm: add apiextensions-aws-config-e2e-chart

### DIFF
--- a/helm/apiextensions-aws-config-e2e-chart/Chart.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/Chart.yaml
@@ -1,3 +1,3 @@
-name: apiextensions-aws-config-e2e
+name: apiextensions-aws-config-e2e-chart
 version: 0.1.0
 description: AwsConfig object used in e2e tests.

--- a/helm/apiextensions-aws-config-e2e-chart/Chart.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: apiextensions-aws-config-e2e
+version: 0.1.0
+description: AwsConfig object used in e2e tests.

--- a/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
@@ -1,0 +1,120 @@
+apiVersion: "provider.giantswarm.io/v1alpha1"
+kind: AWSConfig
+metadata:
+  name: {{.Values.clusterName}}
+spec:
+  cluster:
+    version: "{{.Values.clusterVersion}}"
+
+    id: "{{.Values.clusterName}}"
+
+    customer:
+      id: "example-customer"
+
+    docker:
+      daemon:
+        cidr: "172.17.0.1/16"
+        extraArgs: "--log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+
+    etcd:
+      domain: "etcd.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+      prefix: "giantswarm.io"
+      port: 2379
+
+    calico:
+      subnet: "192.168.0.0"
+      cidr: 16
+      mtu: 1500
+      domain: "calico.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+
+    kubernetes:
+      api:
+        domain: "api.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+        insecurePort: 8080
+        ip: "172.31.0.1"
+        securePort: 443
+        clusterIPRange: "172.31.0.0/24"
+        altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+      cloudProvider: "aws"
+      dns:
+        ip: "172.31.0.10"
+      domain: "cluster.local"
+      hyperkube:
+        docker:
+          image: "quay.io/giantswarm/hyperkube:v1.7.5_coreos.0"
+      ingressController:
+        docker:
+          image: "quay.io/giantswarm/nginx-ingress-controller:0.9.0-beta.11"
+        insecurePort: 30010
+        securePort: 30011
+        domain: "ingress.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+        wildcardDomain: "*.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+      kubectl:
+        docker:
+          image: "quay.io/giantswarm/docker-kubectl:f51f93c30d27927d2b33122994c0929b3e6f2432"
+      kubelet:
+        port: 10250
+        domain: "worker.{{.Values.clusterName}}.{{.Values.commonDomain}}"
+        altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+      networkSetup:
+        docker:
+          image: "quay.io/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9"
+      ssh:
+        userList:
+        - name: "{{.Values.sshUser}}"
+          publicKey: "{{.Values.sshPublicKey}}"
+    masters:
+    - id: "master-1"
+
+    workers:
+    - id: "worker-1"
+    - id: "worker-2"
+
+  aws:
+    region: "{{.Values.aws.region}}"
+    az: "{{.Values.aws.az}}"
+
+    api:
+      hostedZones: "{{.Values.aws.apiHostedZone}}"
+      elb:
+        idleTimeoutSeconds: 1200
+
+    credentialSecret:
+      name: "{{.Values.aws.credentialName}}"
+      namespace: "{{.Values.aws.credentialNamespace}}"
+
+    etcd:
+      hostedZones: "{{.Values.aws.apiHostedZone}}"
+      elb:
+        idleTimeoutSeconds: 3600
+
+    ingress:
+      hostedZones: "{{.Values.aws.apiHostedZone}}"
+      elb:
+        idleTimeoutSeconds: 60
+
+    vpc:
+      cidr: "{{.Values.aws.networkCIDR}}"
+      privateSubnetCidr: "{{.Values.aws.privateSubnetCIDR}}"
+      publicSubnetCidr: "{{.Values.aws.publicSubnetCIDR}}"
+      routeTableNames:
+      - {{.Values.aws.routeTable0}}
+      - {{.Values.aws.routeTable1}}
+      peerId: "{{.Values.aws.vpcPeerId}}"
+
+    masters:
+    - imageID: "{{.Values.aws.ami}}"
+      instanceType: "{{.Values.aws.instanceTypeMaster}}"
+
+    workers:
+    - imageID: "{{.Values.aws.ami}}"
+      instanceType: "{{.Values.aws.instanceTypeWorker}}"
+    - imageID: "{{.Values.aws.ami}}"
+      instanceType: "{{.Values.aws.instanceTypeWorker}}"
+
+  guest:
+    update:
+      enabled: {{.Values.updateEnabled}}
+
+  versionBundle:
+    version: "{{.Values.versionBundleVersion}}"

--- a/helm/apiextensions-aws-config-e2e-chart/templates/encryption.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/templates/encryption.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    clusterID: {{.Values.clusterName}}
+    clusterKey: encryption
+  name: {{.Values.clusterName}}-encryption
+type: Opaque
+data:
+  encryption: {{.Values.encryptionKey}}

--- a/helm/apiextensions-aws-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/values.yaml
@@ -1,0 +1,26 @@
+clusterName: "test-cluster"
+commonDomain: "aws.gigantic.io"
+sshUser: "test-user"
+sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCurvzg5Ia54kb3NZapA6yP00//+Jt6XJNeC7Seq3TeCqMR9x7Snalj19r0lWok1PkRgDo1PXj+3y53zo/wqBrPqN4cQqp00R06kNfnhAgesaRMvYhuyVRQQbfXV5gQg8M= dummy-key"
+encryptionKey: "QitRZGlWeW5WOFo2YmdvMVRwQUQ2UWoxRHZSVEF4MmovajlFb05sT1AzOD0="
+versionBundleVersion: "0.1.0"
+updateEnabled: true
+aws:
+  region: "eu-central-1"
+  az: "eu-central-1a"
+  ami: "ami-d60ad6b9"
+  instanceTypeMaster: "m3.large"
+  instanceTypeWorker: "m3.large"
+
+  networkCIDR: "10.1.12.0/24"
+  privateSubnetCIDR: "10.1.12.0/25"
+  publicSubnetCIDR: "10.1.12.128/25"
+
+  apiHostedZone: "Z*************"
+  ingressHostedZone: "Z*************"
+  routeTable0: "example-table"
+  routeTable1: "example-table-two"
+  vpcPeerId: "vpc-XXXXXXXXX"
+
+  credentialName: "credential-default"
+  credentialNamespace: "giantswarm"


### PR DESCRIPTION
Almost pure copy of aws-resource-lab. Diff:

```diff
diff --git a/../aws-resource-lab/helm/aws-resource-lab-chart/Chart.yaml b/./helm/apiextensions-aws-config-e2e-chart/Chart.yaml
index 29fc713..c972afd 100644
--- a/../aws-resource-lab/helm/aws-resource-lab-chart/Chart.yaml
+++ b/./helm/apiextensions-aws-config-e2e-chart/Chart.yaml
@@ -1,3 +1,3 @@
-name: aws-resource-lab-chart
+name: apiextensions-aws-config-e2e-chart
 version: 0.1.0
-description: aws cluster definition to be used in the aws-operator lab
+description: AwsConfig object used in e2e tests.
```