### PR TITLE
helm: add apiextensions-azure-config-e2e-chart

### DIFF
--- a/helm/apiextensions-azure-config-e2e-chart/Chart.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: apiextensions-azure-config-e2e-chart
+version: 0.1.0
+description: AzureConfig object used in e2e tests.

--- a/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
@@ -1,0 +1,73 @@
+apiVersion: "provider.giantswarm.io/v1alpha1"
+kind: AzureConfig
+metadata:
+  name: "{{ .Values.clusterName }}"
+spec:
+  azure:
+    dnsZones:
+      api:
+        name: "{{ .Values.commonDomain }}"
+        resourceGroup: "{{ .Values.commonDomainResourceGroup }}"
+      etcd:
+        name: "{{ .Values.commonDomain }}"
+        resourceGroup: "{{ .Values.commonDomainResourceGroup }}"
+      ingress:
+        name: "{{ .Values.commonDomain }}"
+        resourceGroup: "{{ .Values.commonDomainResourceGroup }}"
+    location: "{{ .Values.azure.location }}"
+    masters:
+    - vmSize: "{{ .Values.azure.vmSizeMaster }}"
+    workers:
+    - vmSize: "{{ .Values.azure.vmSizeWorker }}"
+    - vmSize: "{{ .Values.azure.vmSizeWorker }}"
+    virtualNetwork:
+      calicoSubnetCIDR: "{{ .Values.azure.calicoSubnetCIDR }}"
+      cidr: "{{ .Values.azure.cidr }}"
+      masterSubnetCIDR: "{{ .Values.azure.masterSubnetCIDR }}"
+      workerSubnetCIDR: "{{ .Values.azure.workerSubnetCIDR }}"
+  cluster:
+    calico:
+      cidr: 16
+      domain: "calico.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+      mtu: 1500
+    customer:
+      id: "example-customer"
+    docker:
+      daemon:
+        cidr: "172.17.0.1/16"
+        extraArgs: "--log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+    etcd:
+      domain: "etcd.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+      prefix: "giantswarm.io"
+      port: 2379
+    id: "{{ .Values.clusterName }}"
+    kubernetes:
+      api:
+        altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+        clusterIPRange: "172.31.0.0/16"
+        domain: "api.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+        insecurePort: 8080
+        ip: "172.31.0.1"
+        securePort: 443
+      cloudProvider: "azure"
+      dns:
+        ip: "172.31.0.10"
+      domain: "cluster.local"
+      ingressController:
+        insecurePort: 30010
+        securePort: 30011
+        domain: "ingress.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+        wildcardDomain: "*.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+      kubelet:
+        altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+        domain: "worker.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+        port: 10250
+      networkSetup:
+        docker:
+          image: "quay.io/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9"
+      ssh:
+        userList:
+        - name: "{{ .Values.sshUser }}"
+          publicKey: "{{ .Values.sshPublicKey }}"
+  versionBundle:
+    version: "{{ .Values.versionBundleVersion }}"

--- a/helm/apiextensions-azure-config-e2e-chart/templates/encryption.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/encryption.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    clusterID: "{{.Values.clusterName}}"
+    clusterKey: "encryption"
+  name: "{{.Values.clusterName}}-encryption"
+type: Opaque
+data:
+  encryption: "{{.Values.encryptionKey}}"

--- a/helm/apiextensions-azure-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/values.yaml
@@ -1,0 +1,15 @@
+clusterName: "test-cluster"
+commonDomain: "test-host-cluster.westeurope.azure.gigantic.io"
+commonDomainResourceGroup: "test-host-cluster"
+sshUser: "test-user"
+sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCurvzg5Ia54kb3NZapA6yP00//+Jt6XJNeC7Seq3TeCqMR9x7Snalj19r0lWok1PkRgDo1PXj+3y53zo/wqBrPqN4cQqp00R06kNfnhAgesaRMvYhuyVRQQbfXV5gQg8M= dummy-key"
+encryptionKey: "QitRZGlWeW5WOFo2YmdvMVRwQUQ2UWoxRHZSVEF4MmovajlFb05sT1AzOD0="
+versionBundleVersion: 0.1.0
+azure:
+  location: "westeurope"
+  vmSizeMaster: "Standard_A1"
+  vmSizeWorker: "Standard_A1"
+  calicoSubnetCIDR: "10.42.128.0/17"
+  cidr: "10.42.0.0/16"
+  masterSubnetCIDR: "10.42.0.0/24"
+  workerSubnetCIDR: "10.42.1.0/24"


### PR DESCRIPTION
```diff
diff --git a/../azure-operator/helm/azure-operator-resource-chart/Chart.yaml b/./helm/apiextensions-azure-config-e2e-chart/Chart.yaml
index 2308961..a1990d9 100644
--- a/../azure-operator/helm/azure-operator-resource-chart/Chart.yaml
+++ b/./helm/apiextensions-azure-config-e2e-chart/Chart.yaml
@@ -1,3 +1,3 @@
-name: azure-resource-chart
+name: apiextensions-azure-config-e2e-chart
 version: 0.1.0
-description: azure cluster definition to be used in the azure-operator lab
+description: AzureConfig object used in e2e tests.
```