### PR TITLE
helm: add apiextensions-aws-cluster-config-e2e-chart

### DIFF
--- a/helm/apiextensions-aws-cluster-config-e2e-chart/Chart.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: apiextensions-aws-cluster-config-e2e-chart
+version: 0.1.0
+description: AwsClusterConfig object used in e2e tests.

--- a/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: "core.giantswarm.io/v1alpha1"
+kind: AWSClusterConfig
+metadata:
+  name: {{ .Values.guest.name }}
+spec:
+  guest:
+    dnsZone: "{{ .Values.guest.dnsZone }}"
+    id: "{{ .Values.guest.id }}"
+    name: "{{ .Values.guest.name }}"
+    owner: "{{ .Values.guest.owner }}"
+  versionBundle:
+    version: "{{ .Values.versionBundle.version}}"

--- a/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
@@ -1,0 +1,7 @@
+guest:
+  name: "test-cluster"
+  dnsZone: "test-cluster.aws.giantswarm.io"
+  id: "test-cluster"
+  owner: "giantswarm"
+versionBundle:
+  version: "0.2.0"


### PR DESCRIPTION
```diff
iff --git a/../cluster-operator/helm/cluster-operator-resource-chart/Chart.yaml b/./helm/apiextensions-aws-cluster-config-e2e-chart/Chart.yaml
index 8816907..70c0c60 100644
--- a/../cluster-operator/helm/cluster-operator-resource-chart/Chart.yaml
+++ b/./helm/apiextensions-aws-cluster-config-e2e-chart/Chart.yaml
@@ -1,3 +1,3 @@
-name: cluster-operator-resource-chart
+name: apiextensions-aws-cluster-config-e2e-chart
 version: 0.1.0
-description: resource definitions to be used in with cluster-operator
+description: AwsClusterConfig object used in e2e tests.
```