### PR TITLE
Fix versionBundle indentation

### DIFF
--- a/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
@@ -9,6 +9,6 @@ spec:
     name: "{{ .Values.guest.name }}"
     owner: "{{ .Values.guest.owner }}"
     versionBundles:
-{{ toYaml .Values.guest.versionBundles | indent 4 -}}
+{{ toYaml .Values.guest.versionBundles | indent 4 }}
   versionBundle:
     version: "{{ .Values.versionBundle.version}}"


### PR DESCRIPTION
Before the fix:
```
fgimenez@innsmouth:~/workspace/gocode/src/github.com/giantswarm/apiextensions/helm/apiextensions-aws-cluster-config-e2e-chart$ helm template .
---
# Source: apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
apiVersion: "core.giantswarm.io/v1alpha1"
kind: AWSClusterConfig
metadata:
  name: test-cluster
spec:
  guest:
    dnsZone: "test-cluster.aws.giantswarm.io"
    id: "test-cluster"
    name: "test-cluster"
    owner: "giantswarm"
    versionBundles:
    - name: aws-operator
      version: 3.1.1
    - name: cert-operator
      version: 0.1.0
    - name: cluster-operator
      version: 0.3.0
    versionBundle:
    version: "0.2.0"
```
after the fix:
```
fgimenez@innsmouth:~/workspace/gocode/src/github.com/giantswarm/apiextensions/helm/apiextensions-aws-cluster-config-e2e-chart$ helm template .
---
# Source: apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
apiVersion: "core.giantswarm.io/v1alpha1"
kind: AWSClusterConfig
metadata:
  name: test-cluster
spec:
  guest:
    dnsZone: "test-cluster.aws.giantswarm.io"
    id: "test-cluster"
    name: "test-cluster"
    owner: "giantswarm"
    versionBundles:
    - name: aws-operator
      version: 3.1.1
    - name: cert-operator
      version: 0.1.0
    - name: cluster-operator
      version: 0.3.0
    
  versionBundle:
    version: "0.2.0"
```