### PR TITLE
Revert vpn cidr

### DIFF
--- a/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
@@ -24,7 +24,6 @@ spec:
       calicoSubnetCIDR: "{{ .Values.azure.calicoSubnetCIDR }}"
       cidr: "{{ .Values.azure.cidr }}"
       masterSubnetCIDR: "{{ .Values.azure.masterSubnetCIDR }}"
-      vpnSubnetCIDR: "{{ .Values.azure.vpnSubnetCIDR }}"
       workerSubnetCIDR: "{{ .Values.azure.workerSubnetCIDR }}"
   cluster:
     calico:

--- a/helm/apiextensions-azure-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/values.yaml
@@ -12,5 +12,4 @@ azure:
   calicoSubnetCIDR: "10.42.128.0/17"
   cidr: "10.42.0.0/16"
   masterSubnetCIDR: "10.42.0.0/24"
-  vpnSubnetCIDR: "10.42.2.0/24"
   workerSubnetCIDR: "10.42.1.0/24"

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -96,6 +96,7 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 	// CIDR is the CIDR for the Virtual Network.
 	CIDR string `json:"cidr" yaml:"cidr"`
 
+	// TODO: remove Master, Worker and Calico subnet cidr after v2 is deleted.
 	// MasterSubnetCIDR is the CIDR for the master subnet.
 	MasterSubnetCIDR string `json:"masterSubnetCIDR" yaml:"masterSubnetCIDR"`
 	// WorkerSubnetCIDR is the CIDR for the worker subnet.

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -98,8 +98,6 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 
 	// MasterSubnetCIDR is the CIDR for the master subnet.
 	MasterSubnetCIDR string `json:"masterSubnetCIDR" yaml:"masterSubnetCIDR"`
-	// VPNSubnetCIDR is the CIDR for the vpn gateway subnet.
-	VPNSubnetCIDR string `json:"vpnSubnetCIDR" yaml:"vpnSubnetCIDR"`
 	// WorkerSubnetCIDR is the CIDR for the worker subnet.
 	WorkerSubnetCIDR string `json:"workerSubnetCIDR" yaml:"workerSubnetCIDR"`
 


### PR DESCRIPTION
As VPN CIDR computation is implemented within the azure-operator (see https://github.com/giantswarm/azure-operator/pull/277), it does not longer belong in apiextensions