### PR TITLE
Add ReleaseVersion to cluster guest types

### DIFF
--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -9,6 +9,7 @@ type ClusterGuestConfig struct {
 	ID             string                            `json:"id" yaml:"id"`
 	Name           string                            `json:"name,omitempty" yaml:"name,omitempty"`
 	Owner          string                            `json:"owner,omitempty" yaml:"owner,omitempty"`
+	ReleaseVersion string                            `json:"releaseVersion,omitempty" yaml:"releaseVersion,omitempty"`
 	VersionBundles []ClusterGuestConfigVersionBundle `json:"versionBundles,omitempty" yaml:"versionBundles,omitempty"`
 }
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#3258

The previous PR got borked and we only need to add a single field. So I've created a fresh PR.