### PR TITLE
removes status subresource

### DIFF
--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -20,6 +20,8 @@ import (
 //         kind: ChartConfig
 //         plural: chartconfigs
 //         singular: chartconfig
+//       subresources:
+//         status: {}
 //
 func NewChartConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{

--- a/pkg/apis/core/v1alpha1/drainer_types.go
+++ b/pkg/apis/core/v1alpha1/drainer_types.go
@@ -22,8 +22,6 @@ import (
 //         kind: DrainerConfig
 //         plural: drainerconfigs
 //         singular: drainerconfig
-//       subresources:
-//         status: {}
 //
 func NewDrainerConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
@@ -43,14 +41,12 @@ func NewDrainerConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Plural:   "drainerconfigs",
 				Singular: "drainerconfig",
 			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
-			},
 		},
 	}
 }
 
 // +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type DrainerConfig struct {

--- a/pkg/clientset/versioned/typed/core/v1alpha1/drainerconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/drainerconfig.go
@@ -37,7 +37,6 @@ type DrainerConfigsGetter interface {
 type DrainerConfigInterface interface {
 	Create(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
 	Update(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
-	UpdateStatus(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.DrainerConfig, error)
@@ -115,22 +114,6 @@ func (c *drainerConfigs) Update(drainerConfig *v1alpha1.DrainerConfig) (result *
 		Namespace(c.ns).
 		Resource("drainerconfigs").
 		Name(drainerConfig.Name).
-		Body(drainerConfig).
-		Do().
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-
-func (c *drainerConfigs) UpdateStatus(drainerConfig *v1alpha1.DrainerConfig) (result *v1alpha1.DrainerConfig, err error) {
-	result = &v1alpha1.DrainerConfig{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("drainerconfigs").
-		Name(drainerConfig.Name).
-		SubResource("status").
 		Body(drainerConfig).
 		Do().
 		Into(result)

--- a/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_drainerconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_drainerconfig.go
@@ -100,18 +100,6 @@ func (c *FakeDrainerConfigs) Update(drainerConfig *v1alpha1.DrainerConfig) (resu
 	return obj.(*v1alpha1.DrainerConfig), err
 }
 
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeDrainerConfigs) UpdateStatus(drainerConfig *v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(drainerconfigsResource, "status", c.ns, drainerConfig), &v1alpha1.DrainerConfig{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.DrainerConfig), err
-}
-
 // Delete takes name of the drainerConfig and deletes it. Returns an error if one occurs.
 func (c *FakeDrainerConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1918. So due to the lack of the enabled support for the status sub resources on certain installations we have to step back here and do it without, just like the node config magic is done now. I am not willing to bother with this more now. I tested and this seems to do the trick. 