### PR TITLE
Add chart operator e2e chart

### DIFF
--- a/helm/apiextensions-chart-config-e2e-chart/Chart.yaml
+++ b/helm/apiextensions-chart-config-e2e-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: apiextensions-chart-config-e2e-chart
+version: 0.1.0
+description: ChartConfig objects to be used in e2e tests.

--- a/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
+++ b/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: "core.giantswarm.io/v1alpha1"
+kind: ChartConfig
+metadata:
+  name: "{{ .Values.chart.name }}"
+  namespace: "{{ .Values.namespace }}"
+spec:
+  chart:
+    channel: "{{ .Values.chart.channel }}"
+    configMap:
+      name: "{{ .Values.chart.configMap.name }}"
+      namespace: "{{ .Values.chart.configMap.namespace }}"
+      resourceVersion: "{{ .Values.chart.configMap.resourceVersion }}"
+    name: "{{ .Values.chart.name }}"
+    namespace: "{{ .Values.chart.namespace }}"
+    release: "{{ .Values.chart.release }}"
+    secret:
+      name: "{{ .Values.chart.secret.name }}"
+      namespace: "{{ .Values.chart.secret.namespace }}"
+      resourceVersion: "{{ .Values.chart.secret.resourceVersion }}"
+  versionBundle:
+    version: "{{ .Values.versionBundleVersion }}"

--- a/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
+++ b/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
@@ -6,16 +6,20 @@ metadata:
 spec:
   chart:
     channel: "{{ .Values.chart.channel }}"
-    configMap:
-      name: "{{ .Values.chart.configMap.name }}"
-      namespace: "{{ .Values.chart.configMap.namespace }}"
-      resourceVersion: "{{ .Values.chart.configMap.resourceVersion }}"
+    {{ if .Values.chart.configMap -}}
+      configMap:
+        name: "{{ .Values.chart.configMap.name }}"
+        namespace: "{{ .Values.chart.configMap.namespace }}"
+        resourceVersion: "{{ .Values.chart.configMap.resourceVersion }}"
+    {{- end -}}
     name: "{{ .Values.chart.name }}"
     namespace: "{{ .Values.chart.namespace }}"
     release: "{{ .Values.chart.release }}"
-    secret:
-      name: "{{ .Values.chart.secret.name }}"
-      namespace: "{{ .Values.chart.secret.namespace }}"
-      resourceVersion: "{{ .Values.chart.secret.resourceVersion }}"
+    {{ if .Values.chart.secret -}}
+      secret:
+        name: "{{ .Values.chart.secret.name }}"
+        namespace: "{{ .Values.chart.secret.namespace }}"
+        resourceVersion: "{{ .Values.chart.secret.resourceVersion }}"
+    {{- end -}}
   versionBundle:
     version: "{{ .Values.versionBundleVersion }}"

--- a/helm/apiextensions-chart-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-chart-config-e2e-chart/values.yaml
@@ -1,0 +1,8 @@
+chart:
+  name: "mychart"
+  channel: "0-2-beta"
+  namespace: "giantswarm"
+  release: "0.2.0"
+
+namespace: "giantswarm"
+versionBundleVersion: "0.1.0"


### PR DESCRIPTION
This is mostly copied over from `chart-operator` here: https://github.com/giantswarm/chart-operator/tree/master/integration/templates
I decided to move this here to align with other operators and to make it possible to reuse this is `cluster` and `release-operator` without importing the `chart-operator`.

towards https://github.com/giantswarm/giantswarm/issues/3390