### PR TITLE
Fix chartconfig templating

### DIFF
--- a/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
+++ b/helm/apiextensions-chart-config-e2e-chart/templates/chartconfig.yaml
@@ -6,20 +6,20 @@ metadata:
 spec:
   chart:
     channel: "{{ .Values.chart.channel }}"
-    {{ if .Values.chart.configMap -}}
-      configMap:
-        name: "{{ .Values.chart.configMap.name }}"
-        namespace: "{{ .Values.chart.configMap.namespace }}"
-        resourceVersion: "{{ .Values.chart.configMap.resourceVersion }}"
-    {{- end -}}
+    {{- if .Values.chart.configMap }}
+    configMap:
+      name: "{{ .Values.chart.configMap.name }}"
+      namespace: "{{ .Values.chart.configMap.namespace }}"
+      resourceVersion: "{{ .Values.chart.configMap.resourceVersion }}"
+    {{- end }}
     name: "{{ .Values.chart.name }}"
     namespace: "{{ .Values.chart.namespace }}"
     release: "{{ .Values.chart.release }}"
-    {{ if .Values.chart.secret -}}
-      secret:
-        name: "{{ .Values.chart.secret.name }}"
-        namespace: "{{ .Values.chart.secret.namespace }}"
-        resourceVersion: "{{ .Values.chart.secret.resourceVersion }}"
-    {{- end -}}
+    {{- if .Values.chart.secret }}
+    secret:
+      name: "{{ .Values.chart.secret.name }}"
+      namespace: "{{ .Values.chart.secret.namespace }}"
+      resourceVersion: "{{ .Values.chart.secret.resourceVersion }}"
+    {{- end }}
   versionBundle:
     version: "{{ .Values.versionBundleVersion }}"


### PR DESCRIPTION
Today I learned that the `-` inside helm templating change stuff and whitespaces are fun.

towards https://github.com/giantswarm/giantswarm/issues/3390