### PR TITLE
adds kubelet labels to provider config CR

### DIFF
--- a/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
@@ -53,9 +53,10 @@ spec:
         docker:
           image: "quay.io/giantswarm/docker-kubectl:f51f93c30d27927d2b33122994c0929b3e6f2432"
       kubelet:
-        port: 10250
-        domain: "worker.{{.Values.clusterName}}.k8s.{{.Values.commonDomain}}"
         altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
+        domain: "worker.{{.Values.clusterName}}.k8s.{{.Values.commonDomain}}"
+        labels: "giantswarm.io/provider=aws,aws-operator.giantswarm.io/version={{ .Values.versionBundleVersion }}"
+        port: 10250
       networkSetup:
         docker:
           image: "quay.io/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9"

--- a/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
@@ -64,6 +64,7 @@ spec:
       kubelet:
         altNames: "kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local"
         domain: "worker.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"
+        labels: "giantswarm.io/provider=azure,azure-operator.giantswarm.io/version={{ .Values.versionBundleVersion }}"
         port: 10250
       networkSetup:
         docker:


### PR DESCRIPTION
As defined in https://github.com/giantswarm/fmt/blob/master/kubernetes/annotations_and_labels.md#common-labels-for-guest-cluster-nodes. See also https://circleci.com/gh/giantswarm/aws-operator/9142 where the issue occured.

```
{giantswarm.io/provider} {missing label}
```

```
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/statusresource/create.go:64","event":"update","level":"warning","message":"retrying status patching due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/ci-wip-21adc-6b509","resource":"status","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/statusresource/create.go:50: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/statusresource/create.go:219: giantswarm.io/provider} {missing label}
```