### PR TITLE
Add master and workers to awsclusterconfig chart

### DIFF
--- a/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/templates/aws-cluster-config.yaml
@@ -6,9 +6,17 @@ spec:
   guest:
     dnsZone: "{{ .Values.guest.dnsZone }}"
     id: "{{ .Values.guest.id }}"
+    masters:
+    - id: master-1
+      instanceType: "{{ .Values.guest.aws.instanceTypeMaster }}"
     name: "{{ .Values.guest.name }}"
     owner: "{{ .Values.guest.owner }}"
     versionBundles:
 {{ toYaml .Values.guest.versionBundles | indent 4 }}
+    workers:
+    - id: worker-1
+      instanceType: "{{ .Values.guest.aws.instanceTypeWorker }}"
+    - id: worker-2
+      instanceType: "{{ .Values.guest.aws.instanceTypeWorker }}"
   versionBundle:
     version: "{{ .Values.versionBundle.version}}"

--- a/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
@@ -2,6 +2,9 @@ guest:
   name: "test-cluster"
   dnsZone: "test-cluster.aws.giantswarm.io"
   id: "test-cluster"
+  aws:
+    instanceTypeMaster: "m5.large"
+    instanceTypeWorker: "m5.large"
   owner: "giantswarm"
   versionBundles:
   - name: aws-operator

--- a/helm/apiextensions-aws-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/values.yaml
@@ -9,8 +9,8 @@ aws:
   region: "eu-central-1"
   az: "eu-central-1a"
   ami: "ami-d60ad6b9"
-  instanceTypeMaster: "m3.large"
-  instanceTypeWorker: "m3.large"
+  instanceTypeMaster: "m5.large"
+  instanceTypeWorker: "m5.large"
 
   networkCIDR: "10.1.12.0/24"
   privateSubnetCIDR: "10.1.12.0/25"


### PR DESCRIPTION
Fixes problem with https://github.com/giantswarm/cluster-operator/pull/220.

The awsclusterconfig CR we create has no workers. So the key.WorkerCount returns 0 and an invalid execution error is returned by the chartconfig service.

