### PR TITLE
Add custom configmap to chartconfig

### DIFF
--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -70,6 +70,9 @@ type ChartConfigSpecChart struct {
 	// ConfigMap references a config map containing values that should be
 	// applied to the chart.
 	ConfigMap ChartConfigSpecConfigMap `json:"configMap" yaml:"configMap"`
+	// CustomConfigMap references a config map containing custom values that should be
+	// applied to the chart.
+	CustomConfigMap ChartConfigSpecConfigMap `json:"customConfigMap" yaml:"customConfigMap"`
 	// Name is the name of the Helm chart to deploy,
 	// e.g. kubernetes-node-exporter.
 	Name string `json:"name" yaml:"name"`

--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -70,8 +70,8 @@ type ChartConfigSpecChart struct {
 	// ConfigMap references a config map containing values that should be
 	// applied to the chart.
 	ConfigMap ChartConfigSpecConfigMap `json:"configMap" yaml:"configMap"`
-	// CustomConfigMap references a config map containing custom values that should be
-	// applied to the chart.
+	// CustomConfigMap references a config map containing custom values.
+	// These custom values are specified by the user to override default values.
 	CustomConfigMap ChartConfigSpecConfigMap `json:"customConfigMap" yaml:"customConfigMap"`
 	// Name is the name of the Helm chart to deploy,
 	// e.g. kubernetes-node-exporter.

--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -70,9 +70,9 @@ type ChartConfigSpecChart struct {
 	// ConfigMap references a config map containing values that should be
 	// applied to the chart.
 	ConfigMap ChartConfigSpecConfigMap `json:"configMap" yaml:"configMap"`
-	// CustomConfigMap references a config map containing custom values.
+	// UserConfigMap references a config map containing custom values.
 	// These custom values are specified by the user to override default values.
-	CustomConfigMap ChartConfigSpecConfigMap `json:"customConfigMap" yaml:"customConfigMap"`
+	UserConfigMap ChartConfigSpecConfigMap `json:"userConfigMap" yaml:"userConfigMap"`
 	// Name is the name of the Helm chart to deploy,
 	// e.g. kubernetes-node-exporter.
 	Name string `json:"name" yaml:"name"`

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -609,6 +609,7 @@ func (in *ChartConfigSpec) DeepCopy() *ChartConfigSpec {
 func (in *ChartConfigSpecChart) DeepCopyInto(out *ChartConfigSpecChart) {
 	*out = *in
 	out.ConfigMap = in.ConfigMap
+	out.CustomConfigMap = in.CustomConfigMap
 	out.Secret = in.Secret
 	return
 }

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -609,7 +609,7 @@ func (in *ChartConfigSpec) DeepCopy() *ChartConfigSpec {
 func (in *ChartConfigSpecChart) DeepCopyInto(out *ChartConfigSpecChart) {
 	*out = *in
 	out.ConfigMap = in.ConfigMap
-	out.CustomConfigMap = in.CustomConfigMap
+	out.UserConfigMap = in.UserConfigMap
 	out.Secret = in.Secret
 	return
 }


### PR DESCRIPTION
Towards part of: https://github.com/giantswarm/giantswarm/pull/4093

Adds a custom configmap that can be configured per cluster, to support custom configurations from customers.