### PR TITLE
fixes version label in KVM chart

### DIFF
--- a/helm/apiextensions-kvm-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-kvm-config-e2e-chart/templates/cluster.yaml
@@ -50,7 +50,7 @@ spec:
       kubelet:
         altNames: kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local
         domain: worker.{{.Values.clusterName}}.{{.Values.baseDomain}}
-        labels: kvm-operator.giantswarm.io/version=2.5.0,giantswarm.io/provider=kvm
+        labels: kvm-operator.giantswarm.io/version={{.Values.versionBundleVersion}},giantswarm.io/provider=kvm
         port: 10250
       networkSetup:
         docker:


### PR DESCRIPTION
This is necessary to have the chart dynamic and relative to the tested version so e2e tests do test the right version at all. This is also necessary to make the e2e update tests work. Otherwise we never see the `Created` cluster status condition. 