### PR TITLE
Update release chart

### DIFF
--- a/helm/apiextensions-release-e2e-chart/templates/release.yaml
+++ b/helm/apiextensions-release-e2e-chart/templates/release.yaml
@@ -1,11 +1,17 @@
 apiVersion: "core.giantswarm.io/v1alpha1"
 kind: Release
 metadata:
-  name: "{{ .Values.operator.name }}"
+  name: "{{ .Values.name }}"
   namespace: "{{ .Values.namespace }}"
 spec:
-  operator:
-    name: "{{ .Values.operator.name }}"
-    version: "{{ .Values.operator.version }}"
+  active: "{{ .Values.active }}"
+  authorities:
+    {{- range .Values.authorities }}
+    - name: "{{ .name }}"
+      version: "{{ .version }}"
+    {{- end }}
+  date: "{{ .Values.date }}"
+  provider: "{{ .Values.provider }}"
+  version: "{{ .Values.version }}"
   versionBundle:
     version: "{{ .Values.versionBundle.version }}"

--- a/helm/apiextensions-release-e2e-chart/values.yaml
+++ b/helm/apiextensions-release-e2e-chart/values.yaml
@@ -1,6 +1,11 @@
+active: "true"
+authorities:
+  - name: "test-operator"
+    version: "1.0.0"
+date: "0001-01-01T00:00:00Z"
+name: "1.0.0"
 namespace: "giantswarm"
-operator:
-  name: "test-operator"
-  version: "0.1.0"
+provider: "aws"
+version: "1.0.0"
 versionBundle:
   version: "0.1.0"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/3313

Executing the helm template (without any overwrites) results in:
```
# Source: apiextensions-release-e2e-chart/templates/release.yaml
apiVersion: "core.giantswarm.io/v1alpha1"
kind: Release
metadata:
  name: "1.0.0"
  namespace: "giantswarm"
spec:
  active: "true"
  authorities:
    - name: "test-operator"
      version: "1.0.0"
  date: "0001-01-01T00:00:00Z"
  provider: "aws"
  version: "1.0.0"
  versionBundle:
    version: "0.1.0"
```
Which should be a valid release CR.