### PR TITLE
Add credentialSecret part to AzureClusterConfig

### DIFF
--- a/pkg/apis/core/v1alpha1/azure_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/azure_cluster_types.go
@@ -60,8 +60,17 @@ type AzureClusterConfigSpec struct {
 
 type AzureClusterConfigSpecGuest struct {
 	ClusterGuestConfig `json:",inline" yaml:",inline"`
-	Masters            []AzureClusterConfigSpecGuestMaster `json:"masters,omitempty" yaml:"masters,omitempty"`
-	Workers            []AzureClusterConfigSpecGuestWorker `json:"workers,omitempty" yaml:"workers,omitempty"`
+	CredentialSecret   AzureClusterConfigSpecGuestCredentialSecret `json:"credentialSecret" yaml:"credentialSecret"`
+	Masters            []AzureClusterConfigSpecGuestMaster         `json:"masters,omitempty" yaml:"masters,omitempty"`
+	Workers            []AzureClusterConfigSpecGuestWorker         `json:"workers,omitempty" yaml:"workers,omitempty"`
+}
+
+// AzureClusterConfigSpecGuestCredentialSecret points to the K8s Secret
+// containing credentials for an Azure subscription in which the tenant cluster
+// should be created.
+type AzureClusterConfigSpecGuestCredentialSecret struct {
+	Name      string `json:"name" yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
 }
 
 type AzureClusterConfigSpecGuestMaster struct {


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3987

This PR aligns the AzureClusterConfig with the AWSClusterConfig in so far that it adds a CredentialSecret field.

We need this in `cluster-service` to be able to get the name of the credentialSecret referenced in a BYOC tenant cluster.