### PR TITLE
makes AZs a number

### DIFF
--- a/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/templates/cluster.yaml
@@ -76,10 +76,7 @@ spec:
 
   aws:
     region: "{{.Values.aws.region}}"
-    availabilityZones:
-      {{ range .Values.aws.availabilityZones }}
-      - {{ . | quote }}
-      {{ end }}
+    availabilityZones: {{ .Values.aws.availabilityZones }}
     # TODO the az field is deprecated after no resource packages v18 in the
     # aws-operator exist anymore.
     #

--- a/helm/apiextensions-aws-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-config-e2e-chart/values.yaml
@@ -7,8 +7,7 @@ versionBundleVersion: "0.1.0"
 updateEnabled: true
 aws:
   region: "eu-central-1"
-  availabilityZones:
-  - "eu-central-1a"
+  availabilityZones: 1
   # TODO the az field is deprecated after no resource packages v18 in the
   # aws-operator exist anymore.
   #

--- a/pkg/apis/provider/v1alpha1/aws_funcs.go
+++ b/pkg/apis/provider/v1alpha1/aws_funcs.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-func (a AWSConfig) AvailabilityZones() []string {
+func (a AWSConfig) AvailabilityZones() int {
 	return a.Spec.AWS.AvailabilityZones
 }
 

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -79,6 +79,15 @@ type AWSConfigSpecAWS struct {
 	// it will not be able to be utilized. Such limitations have to be considered
 	// when designing the network topology and configuring tenant cluster HA via
 	// AvailabilityZones.
+	//
+	// The selection and usage of the actual availability zones for the created
+	// tenant cluster is randomized. In case there are 4 availability zones
+	// provided in the used region and the user selects 2 availability zones, the
+	// actually used availability zones in which tenant cluster workload is put
+	// into will tend to be different across tenant cluster creations. This is
+	// done in order to provide more HA during single availability zone failures.
+	// In case a specific availability zone fails, not all tenant clusters will be
+	// affected due to the described selection process.
 	AvailabilityZones int                  `json:"availabilityZones" yaml:"availabilityZones"`
 	CredentialSecret  CredentialSecret     `json:"credentialSecret" yaml:"credentialSecret"`
 	Etcd              AWSConfigSpecAWSEtcd `json:"etcd" yaml:"etcd"`

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -71,18 +71,15 @@ type AWSConfigSpecAWS struct {
 	//     https://github.com/giantswarm/giantswarm/issues/4507
 	//
 	AZ string `json:"az" yaml:"az"`
-	// AvailabilityZones is a list of AWS availability zone references defining
-	// where to run the tenant cluster's worker nodes. There are limitations on
-	// availability zones settings due to binary IP range splitting. When for
-	// instance choosing 3 availability zones, the configured IP range will be
-	// split into 4 ranges and thus one of it will not be able to be utilized.
-	// Such limitations have to be considered when designing the network topology
-	// and configuring tenant cluster HA via AZs. The elements of the list might
-	// look something like this.
-	//
-	//     eu-west-1a, eu-west-1b
-	//
-	AvailabilityZones []string             `json:"availabilityZones" yaml:"availabilityZones"`
+	// AvailabilityZones is the number of AWS availability zones used to spread
+	// the tenant cluster's worker nodes across. There are limitations on
+	// availability zone settings due to binary IP range splitting and provider
+	// specific region capabilities. When for instance choosing 3 availability
+	// zones, the configured IP range will be split into 4 ranges and thus one of
+	// it will not be able to be utilized. Such limitations have to be considered
+	// when designing the network topology and configuring tenant cluster HA via
+	// AvailabilityZones.
+	AvailabilityZones int                  `json:"availabilityZones" yaml:"availabilityZones"`
 	CredentialSecret  CredentialSecret     `json:"credentialSecret" yaml:"credentialSecret"`
 	Etcd              AWSConfigSpecAWSEtcd `json:"etcd" yaml:"etcd"`
 

--- a/pkg/apis/provider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/provider/v1alpha1/zz_generated.deepcopy.go
@@ -110,11 +110,6 @@ func (in *AWSConfigSpec) DeepCopy() *AWSConfigSpec {
 func (in *AWSConfigSpecAWS) DeepCopyInto(out *AWSConfigSpecAWS) {
 	*out = *in
 	out.API = in.API
-	if in.AvailabilityZones != nil {
-		in, out := &in.AvailabilityZones, &out.AvailabilityZones
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	out.CredentialSecret = in.CredentialSecret
 	out.Etcd = in.Etcd
 	out.HostedZones = in.HostedZones


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/pull/2202. Team Spirit reconsidered the approach of configuring and managing multiple availability zones. Consequence is to simply use a number defined in the `AWSConfig` CR as the `api-spec` already suggests as user input. Background is that we think now the `aws-operator` should do the calculation and randomization of AZs internally. It only gets the available list configured at startup via the `installations` repo and the user input desired for a specific tenant cluster. Validation is also happening on the `api` level. 