### PR TITLE
Add AZs to cluster_guest_types

### DIFF
--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 type ClusterGuestConfig struct {
+	AvailabilityZones int `json:"availability_zones,omitempty" yaml:"availability_zones,omitempty"`
 	// DNSZone for guest cluster is supplemented with host prefixes for
 	// specific services such as Kubernetes API or Etcd. In general this DNS
 	// Zone should start with `k8s` like for example


### PR DESCRIPTION
As I understand it, this is the right way to put this information for `cluster-service` to write it into the CR. Cluster-service then checks the different cluster CRs (for aws, azure and kvm) to recover that information when the cluster searcher is used.

towards https://github.com/giantswarm/giantswarm/pull/2202