### PR TITLE
fixes JSON and YAML tags

### DIFF
--- a/pkg/apis/provider/v1alpha1/status_types.go
+++ b/pkg/apis/provider/v1alpha1/status_types.go
@@ -86,7 +86,7 @@ type StatusClusterNode struct {
 // its own implementation and means in order to fulfil its premise.
 type StatusClusterResource struct {
 	Conditions []StatusClusterResourceCondition `json:"conditions" yaml:"conditions"`
-	Name       string                           `json:"status" yaml:"status"`
+	Name       string                           `json:"name" yaml:"name"`
 }
 
 // StatusClusterResourceCondition expresses the conditions in which an


### PR DESCRIPTION
AFAIK the resource status is only used in the `azure-operator` right now. When this change here is applied the resource status is reset and the reconciliation starts from the beginning again, which it does anyway, because it operates in circles and goes through three different stages. This should not do harm. 