### PR TITLE
Change AZ field to camel casing

### DIFF
--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 type ClusterGuestConfig struct {
-	AvailabilityZones int `json:"availability_zones,omitempty" yaml:"availability_zones,omitempty"`
+	AvailabilityZones int `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
 	// DNSZone for guest cluster is supplemented with host prefixes for
 	// specific services such as Kubernetes API or Etcd. In general this DNS
 	// Zone should start with `k8s` like for example


### PR DESCRIPTION
I added this field in https://github.com/giantswarm/apiextensions/pull/164 - I did a mistake with the `json` and `yaml` fields as we use a different formatting here from `api`. 

I only started to vendor this here: https://github.com/giantswarm/cluster-service/pull/347

So I believe that this change should be fine.

towards https://github.com/giantswarm/giantswarm/pull/2202