### PR TITLE
adds status subresource for NodeConfig and DrainerConfig

### DIFF
--- a/pkg/apis/core/v1alpha1/drainer_types.go
+++ b/pkg/apis/core/v1alpha1/drainer_types.go
@@ -17,6 +17,10 @@ const (
 	DrainerConfigStatusTypeTimeout = "Timeout"
 )
 
+const (
+	kindDrainer = "DrainerConfig"
+)
+
 // NewDrainerConfigCRD returns a new custom resource definition for
 // DrainerConfig. This might look something like the following.
 //
@@ -32,6 +36,8 @@ const (
 //         kind: DrainerConfig
 //         plural: drainerconfigs
 //         singular: drainerconfig
+//       subresources:
+//         status: {}
 //
 func NewDrainerConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
@@ -51,12 +57,21 @@ func NewDrainerConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Plural:   "drainerconfigs",
 				Singular: "drainerconfig",
 			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
 		},
 	}
 }
 
+func NewDrainerTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: version,
+		Kind:       kindDrainer,
+	}
+}
+
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type DrainerConfig struct {

--- a/pkg/apis/core/v1alpha1/node_types.go
+++ b/pkg/apis/core/v1alpha1/node_types.go
@@ -5,6 +5,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	kindNode = "NodeConfig"
+)
+
 // NewNodeConfigCRD returns a new custom resource definition for NodeConfig.
 // This might look something like the following.
 //
@@ -20,6 +24,8 @@ import (
 //         kind: NodeConfig
 //         plural: nodeconfigs
 //         singular: nodeconfig
+//       subresources:
+//         status: {}
 //
 func NewNodeConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
@@ -39,12 +45,21 @@ func NewNodeConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Plural:   "nodeconfigs",
 				Singular: "nodeconfig",
 			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
 		},
 	}
 }
 
+func NewNodeTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: version,
+		Kind:       kindNode,
+	}
+}
+
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type NodeConfig struct {

--- a/pkg/clientset/versioned/typed/core/v1alpha1/drainerconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/drainerconfig.go
@@ -37,6 +37,7 @@ type DrainerConfigsGetter interface {
 type DrainerConfigInterface interface {
 	Create(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
 	Update(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
+	UpdateStatus(*v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.DrainerConfig, error)
@@ -114,6 +115,22 @@ func (c *drainerConfigs) Update(drainerConfig *v1alpha1.DrainerConfig) (result *
 		Namespace(c.ns).
 		Resource("drainerconfigs").
 		Name(drainerConfig.Name).
+		Body(drainerConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *drainerConfigs) UpdateStatus(drainerConfig *v1alpha1.DrainerConfig) (result *v1alpha1.DrainerConfig, err error) {
+	result = &v1alpha1.DrainerConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("drainerconfigs").
+		Name(drainerConfig.Name).
+		SubResource("status").
 		Body(drainerConfig).
 		Do().
 		Into(result)

--- a/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_drainerconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_drainerconfig.go
@@ -100,6 +100,18 @@ func (c *FakeDrainerConfigs) Update(drainerConfig *v1alpha1.DrainerConfig) (resu
 	return obj.(*v1alpha1.DrainerConfig), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDrainerConfigs) UpdateStatus(drainerConfig *v1alpha1.DrainerConfig) (*v1alpha1.DrainerConfig, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(drainerconfigsResource, "status", c.ns, drainerConfig), &v1alpha1.DrainerConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.DrainerConfig), err
+}
+
 // Delete takes name of the drainerConfig and deletes it. Returns an error if one occurs.
 func (c *FakeDrainerConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_nodeconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/fake/fake_nodeconfig.go
@@ -100,6 +100,18 @@ func (c *FakeNodeConfigs) Update(nodeConfig *v1alpha1.NodeConfig) (result *v1alp
 	return obj.(*v1alpha1.NodeConfig), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeNodeConfigs) UpdateStatus(nodeConfig *v1alpha1.NodeConfig) (*v1alpha1.NodeConfig, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(nodeconfigsResource, "status", c.ns, nodeConfig), &v1alpha1.NodeConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.NodeConfig), err
+}
+
 // Delete takes name of the nodeConfig and deletes it. Returns an error if one occurs.
 func (c *FakeNodeConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/clientset/versioned/typed/core/v1alpha1/nodeconfig.go
+++ b/pkg/clientset/versioned/typed/core/v1alpha1/nodeconfig.go
@@ -37,6 +37,7 @@ type NodeConfigsGetter interface {
 type NodeConfigInterface interface {
 	Create(*v1alpha1.NodeConfig) (*v1alpha1.NodeConfig, error)
 	Update(*v1alpha1.NodeConfig) (*v1alpha1.NodeConfig, error)
+	UpdateStatus(*v1alpha1.NodeConfig) (*v1alpha1.NodeConfig, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.NodeConfig, error)
@@ -114,6 +115,22 @@ func (c *nodeConfigs) Update(nodeConfig *v1alpha1.NodeConfig) (result *v1alpha1.
 		Namespace(c.ns).
 		Resource("nodeconfigs").
 		Name(nodeConfig.Name).
+		Body(nodeConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *nodeConfigs) UpdateStatus(nodeConfig *v1alpha1.NodeConfig) (result *v1alpha1.NodeConfig, err error) {
+	result = &v1alpha1.NodeConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("nodeconfigs").
+		Name(nodeConfig.Name).
+		SubResource("status").
 		Body(nodeConfig).
 		Do().
 		Into(result)


### PR DESCRIPTION
As it seems we do not have this enabled yet. I want to get it in for some e2e tests in `operatorkit`. It would also be beneficial to get this straight in the `node-operator` and provider operators where they work against the `DrainerConfig` status. 