### PR TITLE
Remove the ASG Name again

### DIFF
--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -177,8 +177,7 @@ type AWSConfigStatus struct {
 }
 
 type AWSConfigStatusAWS struct {
-	AvailabilityZones    []AWSConfigStatusAWSAvailabilityZone `json:"availabilityZones" yaml:"availabilityZones"`
-	AutoScalingGroupName string                               `json:"autoScalingGroupName" yaml:"autoScalingGroupName"`
+	AvailabilityZones []AWSConfigStatusAWSAvailabilityZone `json:"availabilityZones" yaml:"availabilityZones"`
 }
 
 type AWSConfigStatusAWSAvailabilityZone struct {


### PR DESCRIPTION
This was brought up here:
https://github.com/giantswarm/giantswarm/issues/4543#issuecomment-446606430

With autodiscovery we can simply use the cluster name which we already have in `cluster-operator`. The ASG Name is not needed therefor.

We can simply remove this field because it was just added and nothing uses it.