### PR TITLE
adds deprecation notice for cluster version

### DIFF
--- a/pkg/apis/provider/v1alpha1/cluster_types.go
+++ b/pkg/apis/provider/v1alpha1/cluster_types.go
@@ -13,8 +13,11 @@ type Cluster struct {
 	Kubernetes ClusterKubernetes `json:"kubernetes" yaml:"kubernetes"`
 	Masters    []ClusterNode     `json:"masters" yaml:"masters"`
 	Scaling    ClusterScaling    `json:"scaling" yaml:"scaling"`
-	Version    string            `json:"version" yaml:"version"`
-	Workers    []ClusterNode     `json:"workers" yaml:"workers"`
+
+	// Version is DEPRECATED and should just be dropped.
+	Version string `json:"version" yaml:"version"`
+
+	Workers []ClusterNode `json:"workers" yaml:"workers"`
 }
 
 type ClusterCalico struct {


### PR DESCRIPTION
In https://github.com/giantswarm/kubernetesd/pull/425 was a TODO comment which stated the cluster version can be removed as soon as the legacy resource in the `aws-operator` is gone. I checked the provider operators and think this is safe to deprecate and even remove. We should add the version to https://github.com/giantswarm/giantswarm/issues/2383 if this is true. Please verify. 