### PR TITLE
use date-time instead of date for ReleaseCycle CR

### DIFF
--- a/pkg/apis/release/v1alpha1/release_cycle_types.go
+++ b/pkg/apis/release/v1alpha1/release_cycle_types.go
@@ -26,11 +26,11 @@ var releaseCycleValidation = &apiextensionsv1beta1.CustomResourceValidation{
 				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 					"disabledDate": {
 						Type:   "string",
-						Format: "date",
+						Format: "date-time",
 					},
 					"enabledDate": {
 						Type:   "string",
-						Format: "date",
+						Format: "date-time",
 					},
 					"phase": {
 						Enum: []apiextensionsv1beta1.JSON{


### PR DESCRIPTION
This PR solves an issue where an operator throw the following error when watching ReleaseCycle CR.

```
E0207 14:39:35.302146   31346 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: v1alpha1.ReleaseCycle.Spec: v1alpha1.ReleaseCycleSpec.EnabledDate: DisabledDate: u
nmarshalerDecoder: parsing time ""2019-01-12"" as ""2006-01-02T15:04:05Z07:00"": cannot parse """ as "T", error found in #10 byte of ...|019-01-12","enabledD|..., bigger context ...|8c89a5c143ce"},"spec":{"disable
dDate":"2019-01-12","enabledDate":"2019-01-08","phase":"enabled","rel|...
```

This is due to the fact that by default `time` object are decoded using `time.RFC3339` in [`time.UnmarshalJSON`](https://golang.org/src/time/time.go?s=37288:37335#L1230) which is incompatible with the json-schema [date](http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3.1) format.

`time.RFC3339` expects : `2019-01-12T08:00:00Z`
json-schema `date` expects : `2019-01-12`

This PR changes the json-schema format to `date-time` which match `time.RFC3339` format.