### PR TITLE
Set value for appcatalog name

### DIFF
--- a/helm/apiextensions-app-e2e-chart/values.yaml
+++ b/helm/apiextensions-app-e2e-chart/values.yaml
@@ -15,6 +15,7 @@ app:
   version: "1.0.0"
 
 appCatalog:
+  name: "myapp-catalog"
   title: "myapp-catalog"
   description: "giantswarm app catalog"
   logoUrl: "http://giantswarm.com/catalog-logo.png"


### PR DESCRIPTION
Adds missing value that prevents the chart being installed.