### PR TITLE
Compare version.LastTransitionTime and only fallback to Date

### DIFF
--- a/pkg/apis/provider/v1alpha1/status_funcs.go
+++ b/pkg/apis/provider/v1alpha1/status_funcs.go
@@ -74,7 +74,7 @@ func (s StatusCluster) LatestVersion() string {
 	latest := s.Versions[0]
 
 	for _, v := range s.Versions {
-		if latest.Date.Before(v.Date) {
+		if latest.LastTransitionTime.Time.Before(v.LastTransitionTime.Time) || latest.Date.Before(v.Date) {
 			latest = v
 		}
 	}

--- a/pkg/apis/provider/v1alpha1/status_funcs_test.go
+++ b/pkg/apis/provider/v1alpha1/status_funcs_test.go
@@ -87,6 +87,35 @@ func Test_Provider_Status_LatestVersion(t *testing.T) {
 			},
 			ExpectedSemver: "3.0.0",
 		},
+		{
+			Name: "case 5",
+			StatusCluster: StatusCluster{
+				Versions: []StatusClusterVersion{
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(20, 0),
+						},
+						Date:   time.Time{},
+						Semver: "2.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(30, 0),
+						},
+						Date:   time.Time{},
+						Semver: "3.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(10, 0),
+						},
+						Date:   time.Time{},
+						Semver: "1.0.0",
+					},
+				},
+			},
+			ExpectedSemver: "3.0.0",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Version date has been deprecated and the real comparable value is
LastTransitionTime. In case last transition time is not present, fallback to
compare Date.