### PR TITLE
add Auto Scaling Group name to AWS CR status

### DIFF
--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -178,6 +178,11 @@ type AWSConfigStatus struct {
 
 type AWSConfigStatusAWS struct {
 	AvailabilityZones []AWSConfigStatusAWSAvailabilityZone `json:"availabilityZones" yaml:"availabilityZones"`
+	AutoScalingGroup  AWSConfigStatusAWSAutoScalingGroup   `json:"autoScalingGroup" yaml:"autoScalingGroup"`
+}
+
+type AWSConfigStatusAWSAutoScalingGroup struct {
+	Name string `json:"name"`
 }
 
 type AWSConfigStatusAWSAvailabilityZone struct {


### PR DESCRIPTION
Towards: [giantswarm/giantswarm#5350](https://github.com/giantswarm/giantswarm/issues/5350)
Required by: https://github.com/giantswarm/aws-operator/pull/1415

Provide `AWSConfig.Status.AWSAutoScalingGroup.Name` to store the ASG name.