### PR TITLE
Remove quote for bool type

### DIFF
--- a/helm/apiextensions-app-e2e-chart/templates/app.yaml
+++ b/helm/apiextensions-app-e2e-chart/templates/app.yaml
@@ -12,7 +12,7 @@ spec:
   namespace: "{{ .Values.app.namespace }}"
   {{- if .Values.app.kubeconfig}}
   kubeConfig:
-    inCluster: "{{ .Values.app.kubeconfig.inCluster }}"
+    inCluster: {{ .Values.app.kubeconfig.inCluster }}
     secret:
       name: "{{ .Values.app.kubeconfig.name }}"
       namespace: "{{ .Values.app.kubeconfig.namespace }}"


### PR DESCRIPTION
- To remove errors from deployment as below
```
E0226 16:11:16.349363       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: v1alpha1.App.Spec: v1alpha1.AppSpec.KubeConfig: v1alpha1.AppSpecKubeConfig.InCluster: ReadBool: expect t or f, but found ", error found in #10 byte of ...|Cluster":"false","se|..., bigger context ...|e":"","namespace":""}},"kubeConfig":{"inCluster":"false","secret":{"name":"kubeconfig-secret","names|...
```