### PR TITLE
True as incluster

### DIFF
--- a/helm/apiextensions-app-e2e-chart/values.yaml
+++ b/helm/apiextensions-app-e2e-chart/values.yaml
@@ -6,7 +6,7 @@ app:
   namespace: "giantswarm"
   catalog: "myapp-catalog"
   kubeconfig:
-    inCluster: "false"
+    inCluster: "true"
     name: "kubeconfig-secret"
     namespace: "default"
   config:


### PR DESCRIPTION
Since our e2e test is only about inCluster at the moment, we are getting an error as below

```
{"caller":"github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:347","controller":"app-operator","event":"update","level":"error","loop":"5","message":"stop reconciliation due to error","object":"/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/apps/test-app","stack":"[{/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource_set.go:72: } {/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource_set.go:167: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/kubeconfig/kubeconfig.go:55: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/kubeconfig/kubeconfig.go:71: } {secrets \"kubeconfig-secret\" is forbidden: User \"system:serviceaccount:giantswarm:app-operator\" cannot get secrets in the namespace \"default\"}]","time":"2019-02-28T13:25:45.592862+00:00","version":"479"}
```