### PR TITLE
Add basedomain into flannelconfig

### DIFF
--- a/pkg/apis/core/v1alpha1/flannel_types.go
+++ b/pkg/apis/core/v1alpha1/flannel_types.go
@@ -86,9 +86,10 @@ type FlannelConfigSpecBridgeSpecNTP struct {
 }
 
 type FlannelConfigSpecCluster struct {
-	ID        string `json:"id" yaml:"id"`
-	Customer  string `json:"customer" yaml:"customer"`
-	Namespace string `json:"namespace" yaml:"namespace"`
+	BaseDomain string `json:"baseDomain" yaml:"baseDomain"`
+	ID         string `json:"id" yaml:"id"`
+	Customer   string `json:"customer" yaml:"customer"`
+	Namespace  string `json:"namespace" yaml:"namespace"`
 }
 
 type FlannelConfigSpecFlannel struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3134
There is no info about basedomain to construct etcd endpoint for flannelconfig