### PR TITLE
release: fix marshaling for DeepCopyDate

### DIFF
--- a/pkg/apis/release/v1alpha1/deep_copy.go
+++ b/pkg/apis/release/v1alpha1/deep_copy.go
@@ -10,6 +10,16 @@ type DeepCopyDate struct {
 	time.Time
 }
 
+// MarshalJSON implements the json.Marshaler interface. The time is
+// expected to be a quoted string in yyyy-mm-dd format.
+//
+// NOTE: This method has a value (not pointer) receiver. Otherwise marshalling
+// will stop working for values. When this is a value receiver it works for both.
+func (d DeepCopyDate) MarshalJSON() ([]byte, error) {
+	s := d.Format(`"2006-01-02"`)
+	return []byte(s), nil
+}
+
 // UnmarshalJSON implements the json.Unmarshaler interface. The time is
 // expected to be a quoted string in yyyy-mm-dd format.
 func (d *DeepCopyDate) UnmarshalJSON(data []byte) error {

--- a/pkg/apis/release/v1alpha1/deep_copy_test.go
+++ b/pkg/apis/release/v1alpha1/deep_copy_test.go
@@ -23,7 +23,7 @@ func Test_DeepCopyDate_MarshalJSON(t *testing.T) {
 			errorMatcher: nil,
 		},
 		{
-			name:         "case 1: valid date, zeroed hour",
+			name:         "case 1: valid date, non-zeroed hour",
 			inputDate:    "2019-04-05T12:05:17Z",
 			expectedJSON: `{"testDate":"2019-04-05"}`,
 			errorMatcher: nil,

--- a/pkg/apis/release/v1alpha1/deep_copy_test.go
+++ b/pkg/apis/release/v1alpha1/deep_copy_test.go
@@ -9,51 +9,64 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_DeepCopyDate_UnmarshalJSON(t *testing.T) {
+func Test_DeepCopyDate_MarshalJSON(t *testing.T) {
 	testCases := []struct {
-		name          string
-		inputJSON     string
-		expectedDay   int
-		expectedMonth time.Month
-		expectedYear  int
-		errorMatcher  func(err error) bool
+		name         string
+		inputDate    string
+		expectedJSON string
+		errorMatcher func(err error) bool
 	}{
 		{
-			name:          "case 0: valid date",
-			inputJSON:     `{"testDate": "2019-02-08"}`,
-			expectedDay:   8,
-			expectedMonth: 2,
-			expectedYear:  2019,
-			errorMatcher:  nil,
+			name:         "case 0: valid date",
+			inputDate:    "2019-04-05T00:00:00Z",
+			expectedJSON: `{"testDate":"2019-04-05"}`,
+			errorMatcher: nil,
 		},
 		{
-			name:         "case 1: malformed date",
-			inputJSON:    `{"testDate": "2019-02-08T12:04:00"}`,
-			errorMatcher: func(err error) bool { return err != nil },
-		},
-		{
-			name:          "case 2: null",
-			inputJSON:     `{"testDate": null}`,
-			expectedDay:   1,
-			expectedMonth: 1,
-			expectedYear:  1,
-			errorMatcher:  nil,
-		},
-		{
-			name:         "case 3: wrong type",
-			inputJSON:    `{"testDate": 5}`,
-			errorMatcher: func(err error) bool { return err != nil },
+			name:         "case 1: valid date, zeroed hour",
+			inputDate:    "2019-04-05T12:05:17Z",
+			expectedJSON: `{"testDate":"2019-04-05"}`,
+			errorMatcher: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			type JSONObject struct {
-				TestDate DeepCopyDate `json:"testDate"`
+			date, err := time.Parse(time.RFC3339, tc.inputDate)
+			if !reflect.DeepEqual(nil, err) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(nil, err))
 			}
 
-			var jsonObject JSONObject
-			err := json.Unmarshal([]byte(tc.inputJSON), &jsonObject)
+			vPointer := struct {
+				TestDate *DeepCopyDate `json:"testDate"`
+			}{
+				TestDate: &DeepCopyDate{
+					Time: date,
+				},
+			}
+
+			vValue := struct {
+				TestDate DeepCopyDate `json:"testDate"`
+			}{
+				TestDate: DeepCopyDate{
+					Time: date,
+				},
+			}
+
+			bytesPointer, err := json.Marshal(vPointer)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %v, want matching", err)
+			}
+
+			bytesValue, err := json.Marshal(vValue)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:
@@ -70,14 +83,125 @@ func Test_DeepCopyDate_UnmarshalJSON(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(jsonObject.TestDate.Day(), tc.expectedDay) {
-				t.Errorf("\n\n%s\n", cmp.Diff(jsonObject.TestDate.Day(), tc.expectedDay))
+			if !reflect.DeepEqual(string(bytesPointer), tc.expectedJSON) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(bytesPointer), tc.expectedJSON))
 			}
-			if !reflect.DeepEqual(jsonObject.TestDate.Month(), tc.expectedMonth) {
-				t.Errorf("\n\n%s\n", cmp.Diff(jsonObject.TestDate.Month(), tc.expectedMonth))
+
+			if !reflect.DeepEqual(string(bytesValue), tc.expectedJSON) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(bytesValue), tc.expectedJSON))
 			}
-			if !reflect.DeepEqual(jsonObject.TestDate.Year(), tc.expectedYear) {
-				t.Errorf("\n\n%s\n", cmp.Diff(jsonObject.TestDate.Year(), tc.expectedYear))
+		})
+	}
+}
+
+func Test_DeepCopyDate_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputJSON     string
+		expectedNil   bool
+		expectedDay   int
+		expectedMonth time.Month
+		expectedYear  int
+		errorMatcher  func(err error) bool
+	}{
+		{
+			name:          "case 0: valid date",
+			inputJSON:     `{"testDate":"2019-02-08"}`,
+			expectedNil:   false,
+			expectedDay:   8,
+			expectedMonth: 2,
+			expectedYear:  2019,
+			errorMatcher:  nil,
+		},
+		{
+			name:         "case 1: malformed date",
+			inputJSON:    `{"testDate":"2019-02-08T12:04:00"}`,
+			errorMatcher: func(err error) bool { return err != nil },
+		},
+		{
+			name:          "case 2: null",
+			inputJSON:     `{"testDate":null}`,
+			expectedNil:   true,
+			expectedDay:   1,
+			expectedMonth: 1,
+			expectedYear:  1,
+			errorMatcher:  nil,
+		},
+		{
+			name:         "case 3: wrong type",
+			inputJSON:    `{"testDate":5}`,
+			errorMatcher: func(err error) bool { return err != nil },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			type JSONObjectPointer struct {
+				TestDate *DeepCopyDate `json:"testDate"`
+			}
+
+			type JSONObjectValue struct {
+				TestDate DeepCopyDate `json:"testDate"`
+			}
+
+			var jsonObjectPointer = JSONObjectPointer{TestDate: &DeepCopyDate{}}
+			err := json.Unmarshal([]byte(tc.inputJSON), &jsonObjectPointer)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %v, want matching", err)
+			}
+
+			var jsonObjectValue JSONObjectValue
+			err = json.Unmarshal([]byte(tc.inputJSON), &jsonObjectValue)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			if tc.expectedNil {
+				// We need a nil of the same type. Otherwise won't work with cmp.
+				var nilDeepCopyDate *DeepCopyDate
+				if !reflect.DeepEqual(jsonObjectPointer.TestDate, nilDeepCopyDate) {
+					t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectPointer.TestDate, nilDeepCopyDate))
+				}
+			} else {
+				if !reflect.DeepEqual(jsonObjectPointer.TestDate.Day(), tc.expectedDay) {
+					t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectPointer.TestDate.Day(), tc.expectedDay))
+				}
+				if !reflect.DeepEqual(jsonObjectPointer.TestDate.Month(), tc.expectedMonth) {
+					t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectPointer.TestDate.Month(), tc.expectedMonth))
+				}
+				if !reflect.DeepEqual(jsonObjectPointer.TestDate.Year(), tc.expectedYear) {
+					t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectPointer.TestDate.Year(), tc.expectedYear))
+				}
+			}
+
+			if !reflect.DeepEqual(jsonObjectValue.TestDate.Day(), tc.expectedDay) {
+				t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectValue.TestDate.Day(), tc.expectedDay))
+			}
+			if !reflect.DeepEqual(jsonObjectValue.TestDate.Month(), tc.expectedMonth) {
+				t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectValue.TestDate.Month(), tc.expectedMonth))
+			}
+			if !reflect.DeepEqual(jsonObjectValue.TestDate.Year(), tc.expectedYear) {
+				t.Errorf("\n\n%s\n", cmp.Diff(jsonObjectValue.TestDate.Year(), tc.expectedYear))
 			}
 		})
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5278

Fixes things like:

```
status.cycle.disabledDate in body must be of type date: "0001-01-01T00:00:00Z"
status.cycle.enabledDate in body must be of type date: "0001-01-01T00:00:00Z"
```