### PR TITLE
Reason field into app status

### DIFF
--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -227,7 +227,7 @@ type AppStatusRelease struct {
 	// LastDeployed is the time when the app was last deployed.
 	LastDeployed DeepCopyTime `json:"lastDeployed" yaml:"lastDeployed"`
 	// Reason is the description of the last status of helm release when the app is
-	// not installed successfully, e.g. deploy resource already exists
+	// not installed successfully, e.g. deploy resource already exists.
 	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 	// Status is the status of the deployed app,
 	// e.g. DEPLOYED.

--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -226,6 +226,9 @@ type AppStatus struct {
 type AppStatusRelease struct {
 	// LastDeployed is the time when the app was last deployed.
 	LastDeployed DeepCopyTime `json:"lastDeployed" yaml:"lastDeployed"`
+	// Reason is the description of the last status of helm release when the app is
+	// not installed successfully, e.g. deploy resource already exists
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 	// Status is the status of the deployed app,
 	// e.g. DEPLOYED.
 	Status string `json:"status" yaml:"status"`

--- a/pkg/apis/application/v1alpha1/chart_types.go
+++ b/pkg/apis/application/v1alpha1/chart_types.go
@@ -152,7 +152,7 @@ type ChartStatus struct {
 	// https://docs.helm.sh/developing_charts/#the-chart-yaml-file
 	AppVersion string `json:"appVersion" yaml:"appVersion"`
 	// Reason is the description of the last status of helm release when the chart is
-	// not installed successfully, e.g. deploy resource already exists
+	// not installed successfully, e.g. deploy resource already exists.
 	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 	// Release is the status of the Helm release for the deployed chart.
 	Release ChartStatusRelease `json:"release" yaml:"release"`

--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -116,7 +116,7 @@ type ChartConfigStatus struct {
 	// installed, e.g. DEPLOYED.
 	ReleaseStatus string `json:"releaseStatus" yaml:"releaseStatus"`
 	// Reason is the description of the last status of helm release when the chart is
-	// not installed successfully, e.g. deploy resource already exists
+	// not installed successfully, e.g. deploy resource already exists.
 	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 }
 


### PR DESCRIPTION
- Adding `reason` into `app` status (already added into `chart`, `chartconfig`)