### PR TITLE
Actually use AppSpecUserConfig

### DIFF
--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -123,7 +123,7 @@ type AppSpec struct {
 	// e.g. monitoring
 	Namespace string `json:"namespace" yaml:"namespace"`
 	// UserConfig is the user config to be applied when the app is deployed.
-	UserConfig AppSpecConfig `json:"userConfig" yaml:"userConfig"`
+	UserConfig AppSpecUserConfig `json:"userConfig" yaml:"userConfig"`
 	// Version is the version of the app that should be deployed.
 	// e.g. 1.0.0
 	Version string `json:"version" yaml:"version"`


### PR DESCRIPTION
I noticed that we're not using `AppSpecUserConfig` where I think it should be used.

Alternatively, we could remove `AppSpecUserConfig`, if we think that `App.Spec.Config` and `App.Spec.UserConfig` will be the same type of thing always.

ping @rossf7 

Release operator has implemented it with `UserConfig` as `AppSpecConfig` instead of `AppSpecUserConfig`, so we'd have to make a change there too:

https://github.com/search?q=org%3Agiantswarm+AppSpecConfig&type=Code

ping @rossf7