### PR TITLE
Fix example issuerURL from AWS cluster provider extension spec

### DIFF
--- a/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
+++ b/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
@@ -25,7 +25,7 @@ import (
 //           username: email
 //           groups: groups
 //         clientID: foobar-dex-client
-//         issuerURL: https://dex.8y5kc.fr-east-1.foobar.example.com
+//         issuerURL: https://dex.gatekeeper.fr-east-1.aws.example.com
 //     provider:
 //       credentialSecret:
 //         name: credential-default

--- a/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
+++ b/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
@@ -25,7 +25,7 @@ import (
 //           username: email
 //           groups: groups
 //         clientID: foobar-dex-client
-//         issuerURL: https://dex.gatekeeper.fr-east-1.aws.example.com
+//         issuerURL: https://dex.gatekeeper.eu-central-1.aws.example.com
 //     provider:
 //       credentialSecret:
 //         name: credential-default


### PR DESCRIPTION
IssuerURL cannot point to to-be-created cluster at this point and when it
points to another domain, there shouldn't be cluster ID from to-be-created
cluster present.