### PR TITLE
Import adapted status condition helper functions

### DIFF
--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
@@ -1,5 +1,24 @@
 package v1alpha1
 
+const (
+	ClusterVersionLimit = 5
+)
+
+const (
+	ClusterStatusConditionCreated  = "Created"
+	ClusterStatusConditionCreating = "Creating"
+)
+
+const (
+	ClusterStatusConditionDeleted  = "Deleted"
+	ClusterStatusConditionDeleting = "Deleting"
+)
+
+const (
+	ClusterStatusConditionUpdated  = "Updated"
+	ClusterStatusConditionUpdating = "Updating"
+)
+
 // CommonClusterStatus is shared type to contain provider independent cluster status
 // information.
 type CommonClusterStatus struct {

--- a/pkg/apis/cluster/v1alpha1/status_funcs.go
+++ b/pkg/apis/cluster/v1alpha1/status_funcs.go
@@ -1,0 +1,182 @@
+package v1alpha1
+
+import (
+	"sort"
+	"time"
+)
+
+func (s CommonClusterStatus) GetCreatedCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionCreated)
+}
+
+func (s CommonClusterStatus) GetCreatingCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionCreating)
+}
+
+func (s CommonClusterStatus) GetDeletedCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionDeleted)
+}
+
+func (s CommonClusterStatus) GetDeletingCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionDeleting)
+}
+
+func (s CommonClusterStatus) GetUpdatedCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionUpdated)
+}
+
+func (s CommonClusterStatus) GetUpdatingCondition() CommonClusterStatusCondition {
+	return getCondition(s.Conditions, ClusterStatusConditionUpdating)
+}
+
+func (s CommonClusterStatus) HasCreatedCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionCreated)
+}
+
+func (s CommonClusterStatus) HasCreatingCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionCreating)
+}
+
+func (s CommonClusterStatus) HasDeletedCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionDeleted)
+}
+
+func (s CommonClusterStatus) HasDeletingCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionDeleting)
+}
+
+func (s CommonClusterStatus) HasUpdatedCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionUpdated)
+}
+
+func (s CommonClusterStatus) HasUpdatingCondition() bool {
+	return hasCondition(s.Conditions, ClusterStatusConditionUpdating)
+}
+
+func (s CommonClusterStatus) HasVersion(semver string) bool {
+	return hasVersion(s.Versions, semver)
+}
+
+func (s CommonClusterStatus) LatestVersion() string {
+	if len(s.Versions) == 0 {
+		return ""
+	}
+
+	latest := s.Versions[0]
+
+	for _, v := range s.Versions {
+		if latest.LastTransitionTime.Time.Before(v.LastTransitionTime.Time) {
+			latest = v
+		}
+	}
+
+	return latest.Version
+}
+
+func (s CommonClusterStatus) WithCreatedCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionCreating, ClusterStatusConditionCreated, time.Now())
+}
+
+func (s CommonClusterStatus) WithCreatingCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionCreated, ClusterStatusConditionCreating, time.Now())
+}
+
+func (s CommonClusterStatus) WithDeletedCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionDeleting, ClusterStatusConditionDeleted, time.Now())
+}
+
+func (s CommonClusterStatus) WithDeletingCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionDeleted, ClusterStatusConditionDeleting, time.Now())
+}
+
+func (s CommonClusterStatus) WithNewVersion(version string) []CommonClusterStatusVersion {
+	newVersion := CommonClusterStatusVersion{
+		LastTransitionTime: DeepCopyTime{time.Now()},
+		Version:            version,
+	}
+
+	return withVersion(s.Versions, newVersion, ClusterVersionLimit)
+}
+
+func (s CommonClusterStatus) WithUpdatedCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionUpdating, ClusterStatusConditionUpdated, time.Now())
+}
+
+func (s CommonClusterStatus) WithUpdatingCondition() []CommonClusterStatusCondition {
+	return withCondition(s.Conditions, ClusterStatusConditionUpdated, ClusterStatusConditionUpdating, time.Now())
+}
+
+func getCondition(conditions []CommonClusterStatusCondition, t string) CommonClusterStatusCondition {
+	for _, c := range conditions {
+		if c.Type == t {
+			return c
+		}
+	}
+
+	return CommonClusterStatusCondition{}
+}
+
+func hasCondition(conditions []CommonClusterStatusCondition, t string) bool {
+	for _, c := range conditions {
+		if c.Type == t {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasVersion(versions []CommonClusterStatusVersion, search string) bool {
+	for _, v := range versions {
+		if v.Version == search {
+			return true
+		}
+	}
+
+	return false
+}
+
+func withCondition(conditions []CommonClusterStatusCondition, search string, replace string, t time.Time) []CommonClusterStatusCondition {
+	newConditions := []CommonClusterStatusCondition{
+		{
+			LastTransitionTime: DeepCopyTime{t},
+			Type:               replace,
+		},
+	}
+
+	for _, c := range conditions {
+		if c.Type == search {
+			continue
+		}
+
+		newConditions = append(newConditions, c)
+	}
+
+	return newConditions
+}
+
+// withVersion computes a list of version history using the given list and new
+// version structure to append. withVersion also limits total amount of elements
+// in the list by cutting off the tail with respect to the limit parameter.
+func withVersion(versions []CommonClusterStatusVersion, version CommonClusterStatusVersion, limit int) []CommonClusterStatusVersion {
+	if hasVersion(versions, version.Version) {
+		return versions
+	}
+
+	var newVersions []CommonClusterStatusVersion
+
+	start := 0
+	if len(versions) >= limit {
+		start = len(versions) - limit + 1
+	}
+
+	sort.Sort(sortClusterStatusVersionsByDate(versions))
+
+	for i := start; i < len(versions); i++ {
+		newVersions = append(newVersions, versions[i])
+	}
+
+	newVersions = append(newVersions, version)
+
+	return newVersions
+}

--- a/pkg/apis/cluster/v1alpha1/status_funcs_test.go
+++ b/pkg/apis/cluster/v1alpha1/status_funcs_test.go
@@ -1,0 +1,411 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_Provider_Status_LatestVersion(t *testing.T) {
+	testCases := []struct {
+		Name                string
+		CommonClusterStatus CommonClusterStatus
+		ExpectedVersion     string
+	}{
+		{
+			Name: "case 0",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{},
+			},
+			ExpectedVersion: "",
+		},
+		{
+			Name: "case 1",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+						Version:            "1.0.0",
+					},
+				},
+			},
+			ExpectedVersion: "1.0.0",
+		},
+		{
+			Name: "case 2",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+						Version:            "1.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+						Version:            "2.0.0",
+					},
+				},
+			},
+			ExpectedVersion: "2.0.0",
+		},
+		{
+			Name: "case 3",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+						Version:            "1.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+						Version:            "2.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+						Version:            "3.0.0",
+					},
+				},
+			},
+			ExpectedVersion: "3.0.0",
+		},
+		{
+			Name: "case 4",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+						Version:            "2.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+						Version:            "3.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+						Version:            "1.0.0",
+					},
+				},
+			},
+			ExpectedVersion: "3.0.0",
+		},
+		{
+			Name: "case 5",
+			CommonClusterStatus: CommonClusterStatus{
+				Versions: []CommonClusterStatusVersion{
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(20, 0),
+						},
+						Version: "2.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(30, 0),
+						},
+						Version: "3.0.0",
+					},
+					{
+						LastTransitionTime: DeepCopyTime{
+							time.Unix(10, 0),
+						},
+						Version: "1.0.0",
+					},
+				},
+			},
+			ExpectedVersion: "3.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		semver := tc.CommonClusterStatus.LatestVersion()
+
+		if semver != tc.ExpectedVersion {
+			t.Fatalf("expected %#v got %#v", tc.ExpectedVersion, semver)
+		}
+	}
+}
+
+func Test_Provider_Status_withCondition(t *testing.T) {
+	testTime := time.Unix(20, 0)
+
+	testCases := []struct {
+		Name               string
+		Conditions         []CommonClusterStatusCondition
+		Search             string
+		Replace            string
+		ExpectedConditions []CommonClusterStatusCondition
+	}{
+		{
+			Name:       "case 0",
+			Conditions: []CommonClusterStatusCondition{},
+			Search:     ClusterStatusConditionCreating,
+			Replace:    ClusterStatusConditionCreated,
+			ExpectedConditions: []CommonClusterStatusCondition{
+				{
+					LastTransitionTime: DeepCopyTime{testTime},
+					Type:               ClusterStatusConditionCreated,
+				},
+			},
+		},
+		{
+			Name: "case 1",
+			Conditions: []CommonClusterStatusCondition{
+				{
+					LastTransitionTime: DeepCopyTime{testTime},
+					Type:               ClusterStatusConditionCreating,
+				},
+			},
+			Search:  ClusterStatusConditionCreating,
+			Replace: ClusterStatusConditionCreated,
+			ExpectedConditions: []CommonClusterStatusCondition{
+				{
+					LastTransitionTime: DeepCopyTime{testTime},
+					Type:               ClusterStatusConditionCreated,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		conditions := withCondition(tc.Conditions, tc.Search, tc.Replace, testTime)
+
+		if !reflect.DeepEqual(conditions, tc.ExpectedConditions) {
+			t.Fatalf("%s: expected %#v got %#v", tc.Name, tc.ExpectedConditions, conditions)
+		}
+	}
+}
+
+func Test_Provider_Status_withVersion(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		Versions         []CommonClusterStatusVersion
+		Version          CommonClusterStatusVersion
+		Limit            int
+		ExpectedVersions []CommonClusterStatusVersion
+	}{
+		{
+			Name:     "case 0: list with zero items results in a list with one item",
+			Versions: []CommonClusterStatusVersion{},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+				Version:            "1.0.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+			},
+		},
+		{
+			Name: "case 1: list with one item results in a list with two items",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+				Version:            "1.1.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+			},
+		},
+		{
+			Name: "case 2: list with two items results in a list with three items",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+				Version:            "1.5.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
+				},
+			},
+		},
+		{
+			Name: "case 3: list with three items results in a list with three items due to limit",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+				Version:            "3.0.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
+				},
+			},
+		},
+		{
+			Name: "case 4: list with five items results in a list with three items due to limit",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
+					Version:            "3.2.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+				Version:            "3.3.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
+					Version:            "3.2.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+					Version:            "3.3.0",
+				},
+			},
+		},
+		{
+			Name: "case 5: same as 4 but checking items are ordered by date before cutting off",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
+					Version:            "3.2.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+				Version:            "3.3.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
+					Version:            "3.2.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+					Version:            "3.3.0",
+				},
+			},
+		},
+		{
+			Name: "case 6: list with one item results in a list with one item in case the version already exists",
+			Versions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+			},
+			Version: CommonClusterStatusVersion{
+				LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+				Version:            "1.0.0",
+			},
+			Limit: 3,
+			ExpectedVersions: []CommonClusterStatusVersion{
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			versions := withVersion(tc.Versions, tc.Version, tc.Limit)
+
+			if !reflect.DeepEqual(versions, tc.ExpectedVersions) {
+				t.Fatalf("expected %#v got %#v", tc.ExpectedVersions, versions)
+			}
+		})
+	}
+}

--- a/pkg/apis/cluster/v1alpha1/status_sorts.go
+++ b/pkg/apis/cluster/v1alpha1/status_sorts.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+type sortClusterStatusVersionsByDate []CommonClusterStatusVersion
+
+func (s sortClusterStatusVersionsByDate) Len() int      { return len(s) }
+func (s sortClusterStatusVersionsByDate) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s sortClusterStatusVersionsByDate) Less(i, j int) bool {
+	return s[i].LastTransitionTime.UnixNano() < s[j].LastTransitionTime.UnixNano()
+}


### PR DESCRIPTION
These helper functions are adapted from provider/v1alpha1 that has the previous
status type definion. Status condition status has been dropped as unnecessary and
semver renamed to version. Naming was also slightly adapted here.

Towards https://github.com/giantswarm/cluster-operator/pull/496