### PR TITLE
Remove k8s. label from cluster base domain in example

### DIFF
--- a/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
+++ b/pkg/apis/cluster/v1alpha1/aws_cluster_spec_types.go
@@ -22,7 +22,7 @@ import (
 //     cluster:
 //       description: my fancy cluster
 //       dns:
-//         domain: k8s.gauss.eu-central-1.aws.gigantic.io
+//         domain: gauss.eu-central-1.aws.gigantic.io
 //       oidc:
 //         claims:
 //           username: email


### PR DESCRIPTION
In provider extension for AWS there's cluster's base domain which should not
contain k8s. label as it's added there programmatically when needed. Therefore
remove it.