### PR TITLE
add godoc for history limit constants

### DIFF
--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
@@ -36,7 +36,9 @@ const (
 	ClusterConditionLimit = 5
 	// ClusterVersionLimit is the maximum amount of versions tracked in the
 	// version list of a tenant cluster's status. The limit here is applied to the
-	// total amount of the list's number of entries.
+	// total amount of the list's number of entries. For instance a cluster having
+	// transitioned through 6 cluster upgrades throughout its lifetime will only
+	// track 5 versions in its version list.
 	//
 	//     versions:
 	//     - lastTransitionTime: "2019-02-14T11:18:25.212331926Z"

--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
@@ -50,7 +50,7 @@ const (
 	//     - lastTransitionTime: "2018-10-29T02:09:20.393986006Z"
 	//       version: 3.3.3
 	//
-	ClusterVersionLimit = 5
+	ClusterVersionLimit = 15
 )
 
 const (

--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_types.go
@@ -1,6 +1,55 @@
 package v1alpha1
 
 const (
+	// ClusterConditionLimit is the maximum amount of conditions tracked in the
+	// condition list of a tenant cluster's status. The limit here is applied to
+	// equal condition pairs. For instance a cluster having transitioned through 6
+	// cluster upgrades throughout its lifetime will only track 5 Updating/Updated
+	// condition pairs in its condition list.
+	//
+	//     conditions:
+	//     - lastTransitionTime: "2019-08-23T13:15:19.830177296Z"
+	//       condition: Updated
+	//     - lastTransitionTime: "2019-08-23T12:12:25.942680489Z"
+	//       condition: Updating
+	//     - lastTransitionTime: "2019-08-15T14:27:12.813903533Z"
+	//       condition: Updated
+	//     - lastTransitionTime: "2019-08-15T13:20:16.955248597Z"
+	//       condition: Updating
+	//     - lastTransitionTime: "2019-07-23T09:31:28.761118959Z"
+	//       condition: Updated
+	//     - lastTransitionTime: "2019-07-23T08:15:07.523067044Z"
+	//       condition: Updating
+	//     - lastTransitionTime: "2019-06-17T18:20:30.29872263Z"
+	//       condition: Updated
+	//     - lastTransitionTime: "2019-06-17T17:14:12.707323902Z"
+	//       condition: Updating
+	//     - lastTransitionTime: "2019-06-04T13:14:03.523010234Z"
+	//       condition: Updated
+	//     - lastTransitionTime: "2019-06-04T12:18:09.334829389Z"
+	//       condition: Updating
+	//     - lastTransitionTime: "2019-05-17T11:25:37.495980406Z"
+	//       condition: Created
+	//     - lastTransitionTime: "2019-05-17T10:16:25.736159078Z"
+	//       condition: Creating
+	//
+	ClusterConditionLimit = 5
+	// ClusterVersionLimit is the maximum amount of versions tracked in the
+	// version list of a tenant cluster's status. The limit here is applied to the
+	// total amount of the list's number of entries.
+	//
+	//     versions:
+	//     - lastTransitionTime: "2019-02-14T11:18:25.212331926Z"
+	//       version: 4.6.0
+	//     - lastTransitionTime: "2018-12-05T16:57:58.21652461Z"
+	//       version: 4.4.1
+	//     - lastTransitionTime: "2018-12-05T15:42:22.443182449Z"
+	//       version: 4.2.1
+	//     - lastTransitionTime: "2018-10-29T03:31:08.874296621Z"
+	//       version: 4.2.0
+	//     - lastTransitionTime: "2018-10-29T02:09:20.393986006Z"
+	//       version: 3.3.3
+	//
 	ClusterVersionLimit = 5
 )
 


### PR DESCRIPTION
After some discussions I want to further improve the status of our tenant clusters. Right now the status of our provider config CRs is super messy. Here some real life examples. 

```
    conditions:
    - lastTransitionTime: "2019-04-08T15:52:35.523010234Z"
      status: "True"
      type: Updated
    - lastTransitionTime: "2018-10-25T14:08:04.495980406Z"
      status: "True"
      type: Created
```

```
    versions:
    - date: "0001-01-01T00:00:00Z"
      lastTransitionTime: "2019-02-13T18:58:10.29872263Z"
      semver: 4.6.0
    - date: "2018-10-25T14:08:04.587142611Z"
      lastTransitionTime: "0001-01-01T00:00:00Z"
      semver: 4.2.0
    - date: "2018-12-04T16:21:29.588680843Z"
      lastTransitionTime: "0001-01-01T00:00:00Z"
      semver: 4.4.1
    - date: "0001-01-01T00:00:00Z"
      lastTransitionTime: "2019-04-08T15:52:35.523067044Z"
      semver: 4.8.0
```

What we are aiming for is described in the godoc changes of this PR. 