### PR TITLE
sort status versions to have the latest version on top

### DIFF
--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_funcs.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_funcs.go
@@ -156,27 +156,32 @@ func withCondition(conditions []CommonClusterStatusCondition, search string, rep
 }
 
 // withVersion computes a list of version history using the given list and new
-// version structure to append. withVersion also limits total amount of elements
-// in the list by cutting off the tail with respect to the limit parameter.
+// version structure to append. withVersion also limits the total amount of
+// elements in the list by cutting off the tail with respect to the limit
+// parameter.
 func withVersion(versions []CommonClusterStatusVersion, version CommonClusterStatusVersion, limit int) []CommonClusterStatusVersion {
 	if hasVersion(versions, version.Version) {
 		return versions
 	}
 
+	// Create a copy to not manipulate the input list.
 	var newVersions []CommonClusterStatusVersion
-
-	start := 0
-	if len(versions) >= limit {
-		start = len(versions) - limit + 1
+	for _, v := range versions {
+		newVersions = append(newVersions, v)
 	}
 
-	sort.Sort(sortClusterStatusVersionsByDate(versions))
+	// Sort the versions in a way that the newest version, namely the one with the
+	// highest timestamp, is at the top of the list.
+	sort.Sort(sort.Reverse(sortClusterStatusVersionsByDate(newVersions)))
 
-	for i := start; i < len(versions); i++ {
-		newVersions = append(newVersions, versions[i])
+	// Calculate the index for capping the list in the next step.
+	l := limit - 1
+	if len(newVersions) < l {
+		l = len(newVersions)
 	}
 
-	newVersions = append(newVersions, version)
+	// Cap the list and prepend the new version.
+	newVersions = append([]CommonClusterStatusVersion{version}, newVersions[0:l]...)
 
 	return newVersions
 }

--- a/pkg/apis/cluster/v1alpha1/common_cluster_status_funcs_test.go
+++ b/pkg/apis/cluster/v1alpha1/common_cluster_status_funcs_test.go
@@ -2,8 +2,11 @@ package v1alpha1
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_Provider_Status_LatestVersion(t *testing.T) {
@@ -212,12 +215,12 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 			Limit: 3,
 			ExpectedVersions: []CommonClusterStatusVersion{
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
-					Version:            "1.0.0",
-				},
-				{
 					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
 					Version:            "1.1.0",
+				},
+				{
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
 				},
 			},
 		},
@@ -240,16 +243,16 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 			Limit: 3,
 			ExpectedVersions: []CommonClusterStatusVersion{
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
-					Version:            "1.0.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
+					Version:            "1.5.0",
 				},
 				{
 					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
 					Version:            "1.1.0",
 				},
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
-					Version:            "1.5.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(10, 0)},
+					Version:            "1.0.0",
 				},
 			},
 		},
@@ -276,16 +279,16 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 			Limit: 3,
 			ExpectedVersions: []CommonClusterStatusVersion{
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
-					Version:            "1.1.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
 				},
 				{
 					LastTransitionTime: DeepCopyTime{Time: time.Unix(30, 0)},
 					Version:            "1.5.0",
 				},
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
-					Version:            "3.0.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(20, 0)},
+					Version:            "1.1.0",
 				},
 			},
 		},
@@ -320,16 +323,16 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 			Limit: 3,
 			ExpectedVersions: []CommonClusterStatusVersion{
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
-					Version:            "3.0.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+					Version:            "3.3.0",
 				},
 				{
 					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
 					Version:            "3.2.0",
 				},
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
-					Version:            "3.3.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
 				},
 			},
 		},
@@ -364,16 +367,16 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 			Limit: 3,
 			ExpectedVersions: []CommonClusterStatusVersion{
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
-					Version:            "3.0.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
+					Version:            "3.3.0",
 				},
 				{
 					LastTransitionTime: DeepCopyTime{Time: time.Unix(50, 0)},
 					Version:            "3.2.0",
 				},
 				{
-					LastTransitionTime: DeepCopyTime{Time: time.Unix(60, 0)},
-					Version:            "3.3.0",
+					LastTransitionTime: DeepCopyTime{Time: time.Unix(40, 0)},
+					Version:            "3.0.0",
 				},
 			},
 		},
@@ -399,12 +402,12 @@ func Test_Provider_Status_withVersion(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			versions := withVersion(tc.Versions, tc.Version, tc.Limit)
 
 			if !reflect.DeepEqual(versions, tc.ExpectedVersions) {
-				t.Fatalf("expected %#v got %#v", tc.ExpectedVersions, versions)
+				t.Fatalf("\n\n%s\n", cmp.Diff(versions, tc.ExpectedVersions))
 			}
 		})
 	}


### PR DESCRIPTION
Follow up of https://github.com/giantswarm/apiextensions/pull/254. 