### PR TITLE
Support Kubernetes packages minor range constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,19 +46,19 @@ required = [
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.13.2"
+  version = "~kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.2"
+  version = "~kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.13.2"
+  version = "~kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "kubernetes-1.13.2"
+  version = "~kubernetes-1.13.2"
 
 
 


### PR DESCRIPTION
allows any consumers of this package to to use the minor range above `1.13.3`, such as `1.13.4`

Blocked example from `api`:
```
Could not introduce sigs.k8s.io/controller-runtime@v0.1.12, as it has a dependency on k8s.io/apimachinery with constraint kubernetes-1.13.4, which has no overlap with the following existing constraints:
	kubernetes-1.13.2 from github.com/giantswarm/apiextensions@master
```