### PR TITLE
Revert "Support Kubernetes packages minor range constraint"

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,19 +46,19 @@ required = [
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "~kubernetes-1.13.2"
+  version = "kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "~kubernetes-1.13.2"
+  version = "kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "~kubernetes-1.13.2"
+  version = "kubernetes-1.13.2"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "~kubernetes-1.13.2"
+  version = "kubernetes-1.13.2"
 
 
 


### PR DESCRIPTION
Reverts giantswarm/apiextensions#266

Pretty sure that dep's semver `~` operator won't work without a fully `vX.Y.Z` release verison