### PR TITLE
bumping k8s patch version to 4

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,19 +46,19 @@ required = [
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.13.2"
+  version = "kubernetes-1.13.4"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.2"
+  version = "kubernetes-1.13.4"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.13.2"
+  version = "kubernetes-1.13.4"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "kubernetes-1.13.2"
+  version = "kubernetes-1.13.4"
 
 
 


### PR DESCRIPTION
Since #266 was an invalid approach, I'm bumping the patch version here directly.

Comparrison between tags:
https://github.com/kubernetes/apimachinery/compare/kubernetes-1.13.2..kubernetes-1.13.4