### PR TITLE
Fix chart-operator version as 0.9.0

### DIFF
--- a/helm/apiextensions-app-e2e-chart/values.yaml
+++ b/helm/apiextensions-app-e2e-chart/values.yaml
@@ -22,7 +22,7 @@ apps:
     catalog: "giantswarm-catalog"
     kubeconfig:
       inCluster: "true"
-    version: "1.0.0"
+    version: "0.9.0"
 
 appCatalogs:
   - name: "myapp-catalog"


### PR DESCRIPTION
Following https://github.com/giantswarm/apiextensions/pull/269#discussion_r316692952
> Ack its because you're pulling the tarball from here. Sorry I get it now.
   https://github.com/giantswarm/giantswarm-catalog
   Let's leave it as 0.9.0. Since the chart is being pushed to the catalog and to Quay.