### PR TITLE
Fix wrong kubeConfig access

### DIFF
--- a/helm/apiextensions-app-e2e-chart/templates/app.yaml
+++ b/helm/apiextensions-app-e2e-chart/templates/app.yaml
@@ -16,8 +16,8 @@ spec:
     inCluster: {{ .kubeConfig.inCluster }}
     {{- if not .kubeConfig.inCluster }}
     secret:
-      name: "{{ .kubeconfig.name }}"
-      namespace: "{{ .kubeconfig.namespace }}"
+      name: "{{ .kubeConfig.name }}"
+      namespace: "{{ .kubeConfig.namespace }}"
     {{- end }}
   {{- end }}
   {{- if .config}}


### PR DESCRIPTION
Fixing wrong `kubeconfig` access from go template