### PR TITLE
Add status subresource to chart CRD

### DIFF
--- a/pkg/apis/application/v1alpha1/chart_types.go
+++ b/pkg/apis/application/v1alpha1/chart_types.go
@@ -23,6 +23,8 @@ spec:
     kind: Chart
     plural: charts
     singular: chart
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Adds the status subresource to the CRD YAML. As otherwise UpdateStatus fails in chart-operator.