### PR TITLE
fix APIVersion in NewAppTypeMeta

### DIFF
--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -52,7 +52,7 @@ func NewAppCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 
 func NewAppTypeMeta() metav1.TypeMeta {
 	return metav1.TypeMeta{
-		APIVersion: version,
+		APIVersion: SchemeGroupVersion.String(),
 		Kind:       kindApp,
 	}
 }


### PR DESCRIPTION
This PR fixes the APIVersion returned by `NewAppTypeMeta`.

Currently `NewAppTypeMeta` returns `v1alpha1` which is wrong and should returns `application.giantswarm.io/v1alpha1`.

I know wonder how the entire thing is working without this. Can someone enlighten me please?