### PR TITLE
Use new labels format for encryption key in Azure

### DIFF
--- a/helm/apiextensions-azure-config-e2e-chart/templates/encryption.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/encryption.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    clusterID: "{{.Values.clusterName}}"
-    clusterKey: "encryption"
+    giantswarm.io/cluster: "{{.Values.clusterName}}"
+    giantswarm.io/randomkey: "encryption"
   name: "{{.Values.clusterName}}-encryption"
   namespace: default
 type: Opaque


### PR DESCRIPTION
Labels were changed for AWS but not Azure. So updated randomkeys in deps upgrade broke e2e.