### PR TITLE
Set alt name for internal-api in certconfig

### DIFF
--- a/helm/apiextensions-cert-config-e2e-chart/templates/api-cert.yaml
+++ b/helm/apiextensions-cert-config-e2e-chart/templates/api-cert.yaml
@@ -21,6 +21,7 @@ spec:
     - "kubernetes.default.svc"
     - "kubernetes.default.svc.cluster.local"
     - "master.{{.Values.clusterName}}"
+    - "internal-api.{{.Values.clusterName}}.k8s.{{.Values.commonDomain}}"
     ipSans:
       {{range .Values.ipSans}}
       - {{ . }}


### PR DESCRIPTION
I'm trying to get aws-operator e2e to pass and I noticed the internal API alt name was missing.