### PR TITLE
Added warning for supported golang version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 Package apiextensions provides generated Kubernetes clients for the Giant Swarm
 infrastructure.
 
-## Contributing
-
 ## Golang version
 
 The supported version of golang to be used with this project is ~1.11 (tested 1.11.13).
 Using other GO versions could cause the gen.sh script to fail.
+
+## Contributing
 
 ### Adding a New Group and/or Version
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ infrastructure.
 
 ## Contributing
 
+## Golang version
+
+The supported version of golang to be used with this project is ~1.11 (tested 1.11.13).
+Using other GO versions could cause the gen.sh script to fail.
+
 ### Adding a New Group and/or Version
 
 This is example skeleton for adding new group and/or version.


### PR DESCRIPTION
Don't know if you think this warning could be useful or not; it could have saved me some debugging time and one help request.