### PR TITLE
Added RootVolumeSizeGB field for Azure nodes

### DIFF
--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -112,7 +112,7 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 type AzureConfigSpecAzureNode struct {
 	// VMSize is the master vm size (e.g. Standard_A1)
 	VMSize string `json:"vmSize" yaml:"vmSize"`
-	// Size of a volume mounted to /var/lib/docker.
+	// DockerVolumeSizeGB is the size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
 	// RootVolumeSizeGB is the size of a volume mounted to /.
 	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -114,7 +114,7 @@ type AzureConfigSpecAzureNode struct {
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 	// Size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
-	// Size of a volume mounted to /
+	// RootVolumeSizeGB is the size of a volume mounted to /.
 	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`
 }
 

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -114,6 +114,8 @@ type AzureConfigSpecAzureNode struct {
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 	// Size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
+	// Size of a volume mounted to /
+	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`
 }
 
 type AzureConfigSpecVersionBundle struct {


### PR DESCRIPTION
This edit is related to this issue: https://github.com/giantswarm/giantswarm/issues/7526
Sometimes the customer needs to adjust the size of root disk for master or workers.
I added a new field on the AzureConfig CR to allow for that customization.