### PR TITLE
Removed RootVolumeSizeGB, Added KubeletVolumeSizeGB for azureConfig

### DIFF
--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -114,8 +114,8 @@ type AzureConfigSpecAzureNode struct {
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 	// DockerVolumeSizeGB is the size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
-	// RootVolumeSizeGB is the size of a volume mounted to /.
-	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`
+	// KubeletVolumeSizeGB is the size of a volume mounted to /var/lib/kubelet.
+	KubeletVolumeSizeGB int `json:"kubeletVolumeSizeGB" yaml:"kubeletVolumeSizeGB"`
 }
 
 type AzureConfigSpecVersionBundle struct {


### PR DESCRIPTION
After live discussion, we decided to undo https://github.com/giantswarm/apiextensions/pull/293 and make the Kubelet Volume size adjustable.
That's to allow us to resize the tenant cluster storage size more easily.
Related issue: https://github.com/giantswarm/giantswarm/issues/7526