### PR TITLE
Allow to pass AZ's as a parameter

### DIFF
--- a/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
@@ -32,6 +32,15 @@ spec:
       masterSubnetCIDR: "{{ .Values.azure.masterSubnetCIDR }}"
       workerSubnetCIDR: "{{ .Values.azure.workerSubnetCIDR }}"
   cluster:
+    {{ $azs := splitList " " .Values.azure.availabilityZones }}
+    {{- if (ne .Values.azure.availabilityZones "") and gt (len $azs) 0 -}}
+    availabilityZones:
+    {{ range $azs -}}
+    - {{ . }}
+    {{ end -}}
+    {{ else -}}
+    availabilityZones: []
+    {{ end -}}
     calico:
       cidr: 16
       domain: "calico.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"

--- a/helm/apiextensions-azure-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/values.yaml
@@ -6,6 +6,8 @@ sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCurvzg5Ia54kb3NZapA6yP00//+
 encryptionKey: "QitRZGlWeW5WOFo2YmdvMVRwQUQ2UWoxRHZSVEF4MmovajlFb05sT1AzOD0="
 versionBundleVersion: 0.1.0
 azure:
+  # Space separated list of AZs, e.g availabilityZones: "1 3"
+  availabilityZones: ""
   location: "westeurope"
   vmSizeMaster: "Standard_A1"
   vmSizeWorker: "Standard_A1"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7744

The parameter is a space-separated string containing the numbers of the AZ's to use. I'm using a string instead of an array because this is used for testing, and we will pass the AZ's as env vars when installing the chart, so it's easier to pass strings.

Another option would be to do this when reading the env var here https://github.com/giantswarm/azure-operator/blob/master/integration/env/azure.go
And using a function like
```
func AzureAvailabilityZones() []int {
	azs := strings.Split(strings.TrimSpace(azureAvailabilityZones), " ")
	zones := make([]int, len(azs))

	for i, s := range azs {
		zones[i], _ = strconv.Atoi(s)
	}
	return zones
}
```

WDYT?