### PR TITLE
AZs are part of the Azure field, not the Cluster field

### DIFF
--- a/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
+++ b/helm/apiextensions-azure-config-e2e-chart/templates/cluster.yaml
@@ -7,6 +7,14 @@ metadata:
     giantswarm.io/cluster: "{{ .Values.clusterName }}"
 spec:
   azure:
+    {{ if gt (len .Values.azure.availabilityZones) 0 -}}
+    availabilityZones:
+    {{ range .Values.azure.availabilityZones -}}
+    - {{ . }}
+    {{ end -}}
+    {{ else -}}
+    availabilityZones: []
+    {{ end -}}
     credentialSecret:
       name: "credential-default"
       namespace: "giantswarm"
@@ -32,14 +40,6 @@ spec:
       masterSubnetCIDR: "{{ .Values.azure.masterSubnetCIDR }}"
       workerSubnetCIDR: "{{ .Values.azure.workerSubnetCIDR }}"
   cluster:
-    {{ if gt (len .Values.azure.availabilityZones) 0 -}}
-    availabilityZones:
-    {{ range .Values.azure.availabilityZones -}}
-    - {{ . }}
-    {{ end -}}
-    {{ else -}}
-    availabilityZones: []
-    {{ end -}}
     calico:
       cidr: 16
       domain: "calico.{{ .Values.clusterName }}.k8s.{{ .Values.commonDomain }}"


### PR DESCRIPTION
I placed the configuration for the AZs in the wrong field. The azure-operator expects the AZ's to be part of the `Azure` field, instead of the `Cluster` field.