### PR TITLE
Remove image from components sources from releases

### DIFF
--- a/pkg/apis/core/v1alpha1/ignition_types.go
+++ b/pkg/apis/core/v1alpha1/ignition_types.go
@@ -113,7 +113,6 @@ type IgnitionSpecDockerNetworkSetup struct {
 
 type IgnitionSpecEtcd struct {
 	Domain string `json:"domain" yaml:"domain"`
-	Image  string `json:"image" yaml:"image"`
 	Port   int    `json:"port" yaml:"port"`
 	Prefix string `json:"prefix" yaml:"prefix"`
 }
@@ -175,7 +174,6 @@ type IgnitionSpecKubernetes struct {
 	DNS     IgnitionSpecKubernetesDNS     `json:"dns" yaml:"dns"`
 	Domain  string                        `json:"domain" yaml:"domain"`
 	Kubelet IgnitionSpecKubernetesKubelet `json:"kubelet" yaml:"kubelet"`
-	Image   string                        `json:"image" yaml:"image"`
 	IPRange string                        `json:"iprange" yaml:"iprange"`
 }
 


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/8646

From what I understand, we want to remove images from the ignition CR because it will be looked up dynamically based on TC release. If so, this PR removes etcd and k8s images but leaves the docker network setup env image since that's separate.