### PR TITLE
Modify code block indentation for App

### DIFF
--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -139,43 +139,43 @@ func NewAppTypeMeta() metav1.TypeMeta {
 
 // App CRs might look something like the following.
 //
-//    apiVersion: application.giantswarm.io/v1alpha1
-//    kind: App
-//    metadata:
-//      name: "prometheus"
-//      labels:
-//        app-operator.giantswarm.io/version: "1.0.0"
+//     apiVersion: application.giantswarm.io/v1alpha1
+//     kind: App
+//     metadata:
+//       name: "prometheus"
+//       labels:
+//         app-operator.giantswarm.io/version: "1.0.0"
 //
-//    spec:
-//      catalog: "giantswarm"
-//      name: "prometheus"
-//      namespace: "monitoring"
-//      version: "1.0.0"
-//      config:
-//        configMap:
-//          name: "prometheus-values"
-//          namespace: "monitoring"
-//        secret:
-//          name: "prometheus-secrets"
-//          namespace: "monitoring"
-//        kubeConfig:
-//          inCluster: false
-//          context:
-//            name: "giantswarm-12345"
-//          secret:
-//            name: "giantswarm-12345"
-//            namespace: "giantswarm"
-//          userConfig:
-//            configMap:
-//              name: "prometheus-user-values"
-//              namespace: "monitoring"
+//     spec:
+//       catalog: "giantswarm"
+//       name: "prometheus"
+//       namespace: "monitoring"
+//       version: "1.0.0"
+//       config:
+//         configMap:
+//           name: "prometheus-values"
+//           namespace: "monitoring"
+//         secret:
+//           name: "prometheus-secrets"
+//           namespace: "monitoring"
+//         kubeConfig:
+//           inCluster: false
+//           context:
+//             name: "giantswarm-12345"
+//           secret:
+//             name: "giantswarm-12345"
+//             namespace: "giantswarm"
+//           userConfig:
+//             configMap:
+//               name: "prometheus-user-values"
+//               namespace: "monitoring"
 //
-//    status:
-// 	appVersion: "2.4.3" # Optional value from Chart.yaml with the version of the deployed app.
-//      release:
-//        lastDeployed: "2018-11-30T21:06:20Z"
-//        status: "DEPLOYED"
-//      version: "1.1.0" # Required value from Chart.yaml with the version of the chart.
+//     status:
+//       appVersion: "2.4.3" # Optional value from Chart.yaml with the version of the deployed app.
+//       release:
+//         lastDeployed: "2018-11-30T21:06:20Z"
+//         status: "DEPLOYED"
+//       version: "1.1.0" # Required value from Chart.yaml with the version of the chart.
 //
 type App struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

This sets the code block indentation for the App type from 3 to 4 blanks, in order to check whether this influences the code block rendering with some documentation generation tool.

It also fixes the indentation in line 174.