### PR TITLE
Extend cluster guest type with internal domain

### DIFF
--- a/pkg/apis/core/v1alpha1/cluster_guest_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_guest_types.go
@@ -2,6 +2,9 @@ package v1alpha1
 
 type ClusterGuestConfig struct {
 	AvailabilityZones int `json:"availabilityZones,omitempty" yaml:"availabilityZones,omitempty"`
+	// DNSInternalZone for guest cluster represents intenal domain, used inside tenant cluster
+	// Default value is cluster.local
+	DNSInternalZone string `json:"dnsInternalZone" yaml:"dnsInternalZone"`
 	// DNSZone for guest cluster is supplemented with host prefixes for
 	// specific services such as Kubernetes API or Etcd. In general this DNS
 	// Zone should start with `k8s` like for example


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8979

I need this to be able to pass internal domain value into `certconfig` of legacy `cluster-operator`