### PR TITLE
fix owner reference in godoc example for AWSControlPlane CR

### DIFF
--- a/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -95,11 +95,10 @@ func NewAWSControlPlaneTypeMeta() metav1.TypeMeta {
 //         giantswarm.io/organization: giantswarm
 //         release.giantswarm.io/version: "7.3.1"
 //       name: 8y5kc
-//       ownerReference:
-//         apiVersion: infrastructure.giantswarm.io/v1alpha2
-//         kind: G8sControlPlane
-//         name: 8y5kc
-//         namespace: default
+//       ownerReferences:
+//         - apiVersion: infrastructure.giantswarm.io/v1alpha2
+//           kind: G8sControlPlane
+//           name: 8y5kc
 //     spec:
 //       availabilityZones:
 //         - eu-central-1a


### PR DESCRIPTION
Learning made in https://github.com/giantswarm/aws-operator/pull/2162 the owner reference is actually a list and does not hold a namespace because you cannot define owners outside of the object's namespace by system design. 