### PR TITLE
Remove status and improve docs and examples

### DIFF
--- a/docs/cr/core.giantswarm.io_v1alpha1_ignition.yaml
+++ b/docs/cr/core.giantswarm.io_v1alpha1_ignition.yaml
@@ -1,67 +1,55 @@
 apiVersion: core.giantswarm.io/v1alpha1
 kind: Ignition
 metadata:
+  annotations:
+    giantswarm.io/docs: https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1?tab=doc#Ignition
   creationTimestamp: null
-  name: example
+  name: abc12-master
 spec:
-  apiServerEncryptionKey: ""
-  baseDomain: ""
+  apiServerEncryptionKey: 5fd466f48df84f47bb8006b68f0355ba
+  baseDomain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
   calico:
-    cidr: ""
+    cidr: "16"
     disable: false
-    mtu: ""
-    subnet: ""
-  clusterID: ""
+    mtu: "1430"
+    subnet: 10.250.0.0
+  clusterID: abc12
   disableEncryptionAtRest: false
   docker:
     daemon:
-      cidr: ""
+      cidr: 172.100.0.1/16
     networkSetup:
-      image: ""
+      image: quay.io/giantswarm/k8s-setup-network-environment
   etcd:
-    domain: ""
-    port: 0
+    domain: https://etcd.abc12.k8s.example.eu-west-1.aws.giantswarm.io
+    port: 2379
     prefix: ""
-  extension:
-    files: null
-    units: null
-    users: null
+  extension: {}
   ingress:
     disable: false
-  isMaster: false
+  isMaster: true
   kubernetes:
     api:
-      domain: ""
-      securePort: 0
-    cloudProvider: ""
+      domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+      securePort: 443
+    cloudProvider: aws
     dns:
-      ip: ""
-    domain: ""
-    ipRange: ""
+      ip: 10.1.2.3/32
+    domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+    ipRange: 10.2.3.4/24
     kubelet:
-      domain: ""
+      domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
     oidc:
-      clientID: ""
-      enabled: false
+      clientID: abc12
+      enabled: true
       groupsClaim: ""
-      groupsPrefix: ""
-      issuerUrl: ""
+      groupsPrefix: gs
+      issuerUrl: https://giantswarm.io
       usernameClaim: ""
-      usernamePrefix: ""
-  provider: ""
+      usernamePrefix: gs
+  provider: aws
   registry:
-    domain: ""
-    pullProgressDeadline: ""
+    domain: quay.io
+    pullProgressDeadline: 10s
   sso:
-    publicKey: ""
-status:
-  dataSecretName:
-    name: ""
-    namespace: ""
-    resourceVersion: ""
-  failureMessage: ""
-  failureReason: ""
-  ready: false
-  verification:
-    algorithm: ""
-    hash: ""
+    publicKey: ssh-rsa 1234567890

--- a/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
+++ b/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
@@ -2,7 +2,7 @@ apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
   annotations:
-    giantswarm.io/docs: https://docs.giantswarm.io/reference/releases.release.giantswarm.io/v1alpha1/
+    giantswarm.io/docs: https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1?tab=doc#Release
   creationTimestamp: null
   name: v12.0.0
 spec:

--- a/docs/crd/core.giantswarm.io_ignition.yaml
+++ b/docs/crd/core.giantswarm.io_ignition.yaml
@@ -33,9 +33,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/docs/crd/release.giantswarm.io_release.yaml
+++ b/docs/crd/release.giantswarm.io_release.yaml
@@ -120,9 +120,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/pkg/apis/core/v1alpha1/ignition_types.go
+++ b/pkg/apis/core/v1alpha1/ignition_types.go
@@ -157,11 +157,11 @@ type IgnitionSpecEtcd struct {
 
 type IgnitionSpecExtension struct {
 	// Files is an optional array of files which will be rendered and added to the final node ignition.
-	Files []IgnitionSpecExtensionFile `json:"files" yaml:"files"`
+	Files []IgnitionSpecExtensionFile `json:"files,omitempty" yaml:"files"`
 	// Files is an optional array of systemd units which will be rendered and added to the final node ignition.
-	Units []IgnitionSpecExtensionUnit `json:"units" yaml:"units"`
+	Units []IgnitionSpecExtensionUnit `json:"units,omitempty" yaml:"units"`
 	// Files is an optional array of users which will be added to the final node ignition.
-	Users []IgnitionSpecExtensionUser `json:"users" yaml:"users"`
+	Users []IgnitionSpecExtensionUser `json:"users,omitempty" yaml:"users"`
 }
 
 type IgnitionSpecExtensionFile struct {

--- a/pkg/apis/core/v1alpha1/ignition_types_test.go
+++ b/pkg/apis/core/v1alpha1/ignition_types_test.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
+	"regexp"
 	goruntime "runtime"
 	"testing"
 
@@ -36,34 +36,99 @@ func Test_GenerateIgnitionYAML(t *testing.T) {
 			resource: NewIgnitionCRD(),
 		},
 		{
-			name:     fmt.Sprintf("case 1: %s_%s_ignition.yaml is generate successfully", group, version),
+			name:     fmt.Sprintf("case 1: %s_%s_ignition.yaml is generated successfully", group, version),
 			category: "cr",
 			filename: fmt.Sprintf("%s_%s_ignition.yaml", group, version),
 			resource: &Ignition{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "example",
-				},
 				TypeMeta: NewIgnitionTypeMeta(),
+				ObjectMeta: v1.ObjectMeta{
+					Name: "abc12-master",
+					Annotations: map[string]string{
+						"giantswarm.io/docs": "https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1?tab=doc#Ignition",
+					},
+				},
+				Spec: IgnitionSpec{
+					APIServerEncryptionKey: "5fd466f48df84f47bb8006b68f0355ba",
+					BaseDomain:             "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+					Calico: IgnitionSpecCalico{
+						CIDR:    "16",
+						Disable: false,
+						MTU:     "1430",
+						Subnet:  "10.250.0.0",
+					},
+					ClusterID:               "abc12",
+					DisableEncryptionAtRest: false,
+					Docker: IgnitionSpecDocker{
+						Daemon: IgnitionSpecDockerDaemon{
+							CIDR: "172.100.0.1/16",
+						},
+						NetworkSetup: IgnitionSpecDockerNetworkSetup{
+							Image: "quay.io/giantswarm/k8s-setup-network-environment",
+						},
+					},
+					Etcd: IgnitionSpecEtcd{
+						Domain: "https://etcd.abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+						Port:   2379,
+						Prefix: "",
+					},
+					Extension: IgnitionSpecExtension{
+						Files: nil,
+						Units: nil,
+						Users: nil,
+					},
+					Ingress: IgnitionSpecIngress{
+						Disable: false,
+					},
+					IsMaster: true,
+					Kubernetes: IgnitionSpecKubernetes{
+						API: IgnitionSpecKubernetesAPI{
+							Domain:     "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+							SecurePort: 443,
+						},
+						CloudProvider: "aws",
+						DNS: IgnitionSpecKubernetesDNS{
+							IP: "10.1.2.3/32",
+						},
+						Domain: "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+						Kubelet: IgnitionSpecKubernetesKubelet{
+							Domain: "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+						},
+						IPRange: "10.2.3.4/24",
+						OIDC: IgnitionSpecOIDC{
+							Enabled:        true,
+							ClientID:       "abc12",
+							IssuerURL:      "https://giantswarm.io",
+							UsernameClaim:  "",
+							UsernamePrefix: "gs",
+							GroupsClaim:    "",
+							GroupsPrefix:   "gs",
+						},
+					},
+					Provider: "aws",
+					Registry: IgnitionSpecRegistry{
+						Domain:               "quay.io",
+						PullProgressDeadline: "10s",
+					},
+					SSO: IgnitionSpecSSO{
+						PublicKey: "ssh-rsa 1234567890",
+					},
+				},
 			},
 		},
 	}
 
 	docs := filepath.Join(root, "..", "..", "..", "..", "docs")
-	if *update {
-		if _, err := os.Stat(docs); os.IsNotExist(err) {
-			err = os.Mkdir(docs, 0755)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rendered, err := yaml.Marshal(tc.resource)
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// We don't want a status in the docs YAML for the CR and CRD so that they work with `kubectl create -f <file>.yaml`.
+			// This just strips off the top level `status:` and everything following.
+			re := regexp.MustCompile(`(?ms)^status:.*$`)
+			rendered = re.ReplaceAll(rendered, []byte(""))
 
 			path := filepath.Join(docs, tc.category, tc.filename)
 			if *update {


### PR DESCRIPTION
Since we don't want a status section in our documentation CRDs/CRs, I created this PR to delete `status` after marshaling using a simple regex. This PR includes a few other small fixes to release and ignition CRs.

Other changes:
- remove status
- update docs annotation
- remove directory creation
- use full ignition example