### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] 2020-03-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/apiextensions/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/apiextensions/releases/tag/v0.1.0


### PR DESCRIPTION
To prepare for the (probably) final `dep`-based release, we need a changelog to keep track of versions.