### PR TITLE
Various release changes

### DIFF
--- a/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
+++ b/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
@@ -4,11 +4,50 @@ metadata:
   annotations:
     giantswarm.io/docs: https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1?tab=doc#Release
   creationTimestamp: null
-  name: v12.0.0
+  name: v11.2.0
 spec:
-  apps: []
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.11.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.3
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
+    version: 1.0.2
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.6.0
+  - componentVersion: 0.29.0
+    name: nginx-ingress-controller
+    version: 1.5.0
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
+  - name: app-operator
+    version: 1.0.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.1
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kvm-operator
+    version: 3.10.0
   - name: kubernetes
-    version: 1.18.0
-  state: wip
-  version: 12.0.0
+    version: 1.16.3
+  - name: containerlinux
+    version: "2247.6"
+  - name: coredns
+    version: 1.6.5
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+  date: "2020-03-03T11:12:13Z"
+  state: active

--- a/docs/crd/release.giantswarm.io_release.yaml
+++ b/docs/crd/release.giantswarm.io_release.yaml
@@ -13,7 +13,7 @@ spec:
     description: State of the release
     name: State
     type: string
-  - JSONPath: .metadata.creationTimestamp
+  - JSONPath: .spec.date
     description: Time since release creation
     name: Age
     type: date
@@ -94,6 +94,9 @@ spec:
                 type: object
               minItems: 1
               type: array
+            date:
+              format: date-time
+              type: string
             state:
               description: |
                 State indicates how this release should be used. "wip" means the release is a work
@@ -102,16 +105,11 @@ spec:
                 supported release.
               pattern: ^(active|deprecated|wip)$
               type: string
-            version:
-              description: |
-                Semantic version of the release.
-              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
-              type: string
           required:
           - components
           - apps
           - state
-          - version
+          - date
           type: object
       required:
       - metadata

--- a/pkg/apis/release/v1alpha1/deep_copy.go
+++ b/pkg/apis/release/v1alpha1/deep_copy.go
@@ -38,3 +38,13 @@ func (d *DeepCopyDate) UnmarshalJSON(data []byte) error {
 func (d *DeepCopyDate) DeepCopyInto(out *DeepCopyDate) {
 	*out = *d
 }
+
+// DeepCopyTime implements the deep copy logic for time.Time which the k8s
+// codegen is not able to generate out of the box.
+type DeepCopyTime struct {
+	time.Time
+}
+
+func (in *DeepCopyTime) DeepCopyInto(out *DeepCopyTime) {
+	*out = *in
+}

--- a/pkg/apis/release/v1alpha1/release_types_test.go
+++ b/pkg/apis/release/v1alpha1/release_types_test.go
@@ -10,6 +10,7 @@ import (
 	goruntime "runtime"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/errors"
 	"github.com/google/go-cmp/cmp"
@@ -67,9 +68,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 					Value: nil,
 				},
 				{
-					Name:  "spec.version",
+					Name:  "spec.date",
 					In:    "body",
-					Value: nil,
+					Value: "null",
 				},
 			},
 		},
@@ -81,8 +82,8 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
 					Apps: []ReleaseSpecApp{
 						{
 							Name:             "test-app",
@@ -108,8 +109,8 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
 					Apps: []ReleaseSpecApp{
 						{
 							Name:             "test-app",
@@ -136,9 +137,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -157,9 +158,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -183,9 +184,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "v13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -195,10 +196,6 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 			},
 			errors: []*errors.Validation{
-				{
-					Name: "spec.version",
-					In:   "body",
-				},
 				{
 					Name: "spec.components.version",
 					In:   "body",
@@ -213,9 +210,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   "bad",
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: "bad",
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -239,9 +236,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -260,9 +257,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -286,9 +283,9 @@ func Test_ReleaseCRValidation(t *testing.T) {
 				},
 				TypeMeta: NewReleaseTypeMeta(),
 				Spec: ReleaseSpec{
-					State:   stateActive,
-					Version: "13.1.2",
-					Apps:    []ReleaseSpecApp{},
+					State: stateActive,
+					Date:  &DeepCopyTime{time.Now()},
+					Apps:  []ReleaseSpecApp{},
 					Components: []ReleaseSpecComponent{
 						{
 							Name:    "kubernetes",
@@ -326,7 +323,7 @@ func Test_ReleaseCRValidation(t *testing.T) {
 		result := validator.Validate(tc.cr)
 
 		if !cmp.Equal(len(result.Errors), len(tc.errors)) {
-			t.Errorf("\n\n%s %s\n", tc.name, cmp.Diff(len(result.Errors), len(tc.errors)))
+			t.Fatalf("\n\n%s %s\n", tc.name, cmp.Diff(len(result.Errors), len(tc.errors)))
 		}
 
 		var validationErrors []*errors.Validation
@@ -348,6 +345,97 @@ func Test_ReleaseCRValidation(t *testing.T) {
 	}
 }
 
+func newReleaseExampleCR() *Release {
+	cr := NewReleaseCR()
+	cr.Name = "v11.2.0"
+	cr.Spec = ReleaseSpec{
+		Apps: []ReleaseSpecApp{
+			{
+				Name:    "cert-exporter",
+				Version: "1.2.1",
+			},
+			{
+				Name:    "chart-operator",
+				Version: "0.11.4",
+			},
+			{
+				Name:             "coredns",
+				ComponentVersion: "1.6.5",
+				Version:          "1.1.3",
+			},
+			{
+				Name:             "kube-state-metrics",
+				ComponentVersion: "1.9.2",
+				Version:          "1.0.2",
+			},
+			{
+				Name:             "metrics-server",
+				ComponentVersion: "0.3.3",
+				Version:          "1.0.0",
+			},
+			{
+				Name:    "net-exporter",
+				Version: "1.6.0",
+			},
+			{
+				Name:             "nginx-ingress-controller",
+				ComponentVersion: "0.29.0",
+				Version:          "1.5.0",
+			},
+			{
+				Name:             "node-exporter",
+				ComponentVersion: "0.18.1",
+				Version:          "1.2.0",
+			},
+		},
+		Components: []ReleaseSpecComponent{
+			{
+				Name:    "app-operator",
+				Version: "1.0.0",
+			},
+			{
+				Name:    "cert-operator",
+				Version: "0.1.0",
+			},
+			{
+				Name:    "cluster-operator",
+				Version: "0.23.1",
+			},
+			{
+				Name:    "flannel-operator",
+				Version: "0.2.0",
+			},
+			{
+				Name:    "kvm-operator",
+				Version: "3.10.0",
+			},
+			{
+				Name:    "kubernetes",
+				Version: "1.16.3",
+			},
+			{
+				Name:    "containerlinux",
+				Version: "2247.6",
+			},
+			{
+				Name:    "coredns",
+				Version: "1.6.5",
+			},
+			{
+				Name:    "calico",
+				Version: "3.10.1",
+			},
+			{
+				Name:    "etcd",
+				Version: "3.3.17",
+			},
+		},
+		Date:  &DeepCopyTime{time.Date(2020, 3, 3, 11, 12, 13, 0, time.UTC)},
+		State: stateActive,
+	}
+	return cr
+}
+
 func Test_GenerateReleaseYAML(t *testing.T) {
 	testCases := []struct {
 		category string
@@ -362,26 +450,7 @@ func Test_GenerateReleaseYAML(t *testing.T) {
 		{
 			category: "cr",
 			name:     fmt.Sprintf("%s_%s_release.yaml", group, version),
-			resource: &Release{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "v12.0.0",
-					Annotations: map[string]string{
-						"giantswarm.io/docs": "https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1?tab=doc#Release",
-					},
-				},
-				TypeMeta: NewReleaseTypeMeta(),
-				Spec: ReleaseSpec{
-					Apps: []ReleaseSpecApp{},
-					Components: []ReleaseSpecComponent{
-						{
-							Name:    "kubernetes",
-							Version: "1.18.0",
-						},
-					},
-					State:   stateWIP,
-					Version: "12.0.0",
-				},
-			},
+			resource: newReleaseExampleCR(),
 		},
 	}
 
@@ -397,8 +466,8 @@ func Test_GenerateReleaseYAML(t *testing.T) {
 
 			// We don't want a status in the docs YAML for the CR and CRD so that they work with `kubectl create -f <file>.yaml`.
 			// This just strips off the top level `status:` and everything following.
-			re := regexp.MustCompile(`(?ms)^status:.*$`)
-			rendered = re.ReplaceAll(rendered, []byte(""))
+			statusRegex := regexp.MustCompile(`(?ms)^status:.*$`)
+			rendered = statusRegex.ReplaceAll(rendered, []byte(""))
 
 			if *update {
 				err := ioutil.WriteFile(path, rendered, 0644)


### PR DESCRIPTION
Towards https://github.com/giantswarm/releases/pull/142

We can't set `creationTimestamp` to reflect the release date so we need a separate date in the `spec`. I added this field with tests and improved the example `Release` for our docs since it wasn't showing much before.

I also took this opportunity to remove `version` after a [team discussion](https://gigantic.slack.com/archives/CHAHY6VMF/p1582851678004100?thread_ts=1582851678.004100&cid=CHAHY6VMF). There are good reasons to keep it and good reasons to get rid of it. In general, Kubernetes resource names should not have meaning. The name is metadata and the important information should be in the spec and status. At the same time, we are able to validate names with OpenAPI and stateful sets do use meaningful pod names. Moreover, getting the version from the name ensures that names are unique. Lastly, the name and .spec.version will always be equal for the foreseeable future so this is just repeated information. I feel this is sufficient reason to go this route but am willing to consider other arguments to the contrary.