### PR TITLE
Remove not-actually-released v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] 2020-03-03
+## [Unreleased]
 
 ### Added
 
 - First release.
 
-[Unreleased]: https://github.com/giantswarm/apiextensions/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/giantswarm/apiextensions/releases/tag/v0.1.0
+[Unreleased]: https://github.com/giantswarm/apiextensions


### PR DESCRIPTION
Towards https://github.com/giantswarm/apiextensions/pull/319#pullrequestreview-367972451 and in response to https://github.com/giantswarm/apiextensions/pull/344#issuecomment-594471396

I added `v0.1.0` in a `CHANGELOG`, but as discussed recently we should make releases separate from any other changes, so I'm removing 0.1.0 and making everything unreleased until it's actually ready to go.