### PR TITLE
Fix indentation in the AWSCluster CRD YAML

### DIFF
--- a/docs/crd/infrastructure.giantswarm.io_awscluster.yaml
+++ b/docs/crd/infrastructure.giantswarm.io_awscluster.yaml
@@ -4,66 +4,81 @@ metadata:
   creationTimestamp: null
   name: awsclusters.infrastructure.giantswarm.io
 spec:
+  conversion:
+    strategy: None
   group: infrastructure.giantswarm.io
   names:
     kind: AWSCluster
+    listKind: AWSClusterList
     plural: awsclusters
     singular: awscluster
+  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: |
-        Defines a tenant cluster in a Giant Swarm AWS installation.
-        Introduced with release v10.x.x, reconciled by aws-operator.
-      properties:
-        spec:
-          properties:
-            cluster:
-              description: |
-                Provides cluster specification details.
-              properties:
-                description:
-                  description: |
-                    User-friendly description that should explain the purpose of the
-                    cluster.
-                  maxLength: 100
-                  type: string
-                dns:
-                  description: |
-                    DNS configuration details.
-                  properties:
-                    domain:
-                      description: |
-                        Base domain for several endpoints of this cluster.
-                      type: string
-                  type: object
-                oidc:
-                  description: |
-                    Configuration for OpenID Connect (OIDC) authentication.
-                  type: object
-            provider:
-              description: |
-                AWS-specific configuration details.
-              properties:
-                master:
-                  description: |
-                    Master node configuration details.
-                  properties:
-                    availabilityZone:
-                      description: |
-                        Name of the AWS Availability Zone to place the master node in.
-                      type: string
-                    instanceType:
-                      description: |
-                        EC2 instance type to use for the master node.
-                      type: string
-                  type: object
-                region:
-                  description: |
-                    AWS region the cluster is to be running in.
-                  type: string
-              type: object
-          type: object
-  version: v1alpha2
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+    served: false
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |
+          Defines a tenant cluster in a Giant Swarm AWS installation.
+          Introduced with release v10.x.x, reconciled by aws-operator.
+        properties:
+          spec:
+            properties:
+              cluster:
+                description: |
+                  Provides cluster specification details.
+                properties:
+                  description:
+                    description: |
+                      User-friendly description that should explain the purpose of the
+                      cluster.
+                    maxLength: 100
+                    type: string
+                  dns:
+                    description: |
+                      DNS configuration details.
+                    properties:
+                      domain:
+                        description: |
+                          Base domain for several endpoints of this cluster.
+                        type: string
+                    type: object
+                  oidc:
+                    description: |
+                      Configuration for OpenID Connect (OIDC) authentication.
+                    type: object
+                type: object
+              provider:
+                description: |
+                  AWS-specific configuration details.
+                properties:
+                  master:
+                    description: |
+                      Master node configuration details.
+                    properties:
+                      availabilityZone:
+                        description: |
+                          Name of the AWS Availability Zone to place the master node in.
+                        type: string
+                      instanceType:
+                        description: |
+                          EC2 instance type to use for the master node.
+                        type: string
+                    type: object
+                  region:
+                    description: |
+                      AWS region the cluster is to be running in.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/crd/infrastructure.giantswarm.io_awscluster.yaml
+++ b/docs/crd/infrastructure.giantswarm.io_awscluster.yaml
@@ -38,32 +38,32 @@ spec:
                       description: |
                         Base domain for several endpoints of this cluster.
                       type: string
-                    provider:
-                      description: |
-                        AWS-specific configuration details.
-                      properties:
-                        master:
-                          description: |
-                            Master node configuration details.
-                          properties:
-                            availabilityZone:
-                              description: |
-                                Name of the AWS Availability Zone to place the master node in.
-                              type: string
-                            instanceType:
-                              description: |
-                                EC2 instance type to use for the master node.
-                              type: string
-                          type: object
-                        region:
-                          description: |
-                            AWS region the cluster is to be running in.
-                          type: string
-                      type: object
                   type: object
                 oidc:
                   description: |
                     Configuration for OpenID Connect (OIDC) authentication.
+                  type: object
+            provider:
+              description: |
+                AWS-specific configuration details.
+              properties:
+                master:
+                  description: |
+                    Master node configuration details.
+                  properties:
+                    availabilityZone:
+                      description: |
+                        Name of the AWS Availability Zone to place the master node in.
+                      type: string
+                    instanceType:
+                      description: |
+                        EC2 instance type to use for the master node.
+                      type: string
+                  type: object
+                region:
+                  description: |
+                    AWS region the cluster is to be running in.
+                  type: string
               type: object
           type: object
   version: v1alpha2

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -18,69 +18,85 @@ kind: CustomResourceDefinition
 metadata:
   name: awsclusters.infrastructure.giantswarm.io
 spec:
+  conversion:
+    strategy: None
   group: infrastructure.giantswarm.io
   names:
     kind: AWSCluster
+    listKind: AWSClusterList
     plural: awsclusters
     singular: awscluster
+  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha2
-  validation:
-    openAPIV3Schema:
-      description: |
-        Defines a tenant cluster in a Giant Swarm AWS installation.
-        Introduced with release v10.x.x, reconciled by aws-operator.
-      properties:
-        spec:
-          type: object
-          properties:
-            cluster:
-              description: |
-                Provides cluster specification details.
-              properties:
-                description:
-                  description: |
-                    User-friendly description that should explain the purpose of the
-                    cluster.
-                  maxLength: 100
-                  type: string
-                dns:
-                  description: |
-                    DNS configuration details.
-                  type: object
-                  properties:
-                    domain:
-                      description: |
-                        Base domain for several endpoints of this cluster.
-                      type: string
-                oidc:
-                  description: |
-                    Configuration for OpenID Connect (OIDC) authentication.
-                  type: object
-            provider:
-              description: |
-                AWS-specific configuration details.
-              type: object
-              properties:
-                master:
-                  description: |
-                    Master node configuration details.
-                  type: object
-                  properties:
-                    availabilityZone:
-                      description: |
-                        Name of the AWS Availability Zone to place the master node in.
-                      type: string
-                    instanceType:
-                      description: |
-                        EC2 instance type to use for the master node.
-                      type: string
-                region:
-                  description: |
-                    AWS region the cluster is to be running in.
-                  type: string
+  versions:
+  - name: v1alpha1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties: {}
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: |
+          Defines a tenant cluster in a Giant Swarm AWS installation.
+          Introduced with release v10.x.x, reconciled by aws-operator.
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cluster:
+                description: |
+                  Provides cluster specification details.
+                type: object
+                properties:
+                  description:
+                    description: |
+                      User-friendly description that should explain the purpose of the
+                      cluster.
+                    maxLength: 100
+                    type: string
+                  dns:
+                    description: |
+                      DNS configuration details.
+                    type: object
+                    properties:
+                      domain:
+                        description: |
+                          Base domain for several endpoints of this cluster.
+                        type: string
+                  oidc:
+                    description: |
+                      Configuration for OpenID Connect (OIDC) authentication.
+                    type: object
+              provider:
+                description: |
+                  AWS-specific configuration details.
+                type: object
+                properties:
+                  master:
+                    description: |
+                      Master node configuration details.
+                    type: object
+                    properties:
+                      availabilityZone:
+                        description: |
+                          Name of the AWS Availability Zone to place the master node in.
+                        type: string
+                      instanceType:
+                        description: |
+                          EC2 instance type to use for the master node.
+                        type: string
+                  region:
+                    description: |
+                      AWS region the cluster is to be running in.
+                    type: string
+    subresources:
+      status: {}
 `
 
 var awsClusterCRD *apiextensionsv1beta1.CustomResourceDefinition

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -26,6 +26,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  version: v1alpha2
   validation:
     openAPIV3Schema:
       description: |
@@ -33,6 +34,7 @@ spec:
         Introduced with release v10.x.x, reconciled by aws-operator.
       properties:
         spec:
+          type: object
           properties:
             cluster:
               description: |
@@ -47,40 +49,38 @@ spec:
                 dns:
                   description: |
                     DNS configuration details.
+                  type: object
                   properties:
                     domain:
                       description: |
                         Base domain for several endpoints of this cluster.
                       type: string
-                    provider:
-                      description: |
-                        AWS-specific configuration details.
-                      properties:
-                        master:
-                          description: |
-                            Master node configuration details.
-                          properties:
-                            availabilityZone:
-                              description: |
-                                Name of the AWS Availability Zone to place the master node in.
-                              type: string
-                            instanceType:
-                              description: |
-                                EC2 instance type to use for the master node.
-                              type: string
-                          type: object
-                        region:
-                          description: |
-                            AWS region the cluster is to be running in.
-                          type: string
-                      type: object
-                  type: object
                 oidc:
                   description: |
                     Configuration for OpenID Connect (OIDC) authentication.
+                  type: object
+            provider:
+              description: |
+                AWS-specific configuration details.
               type: object
-          type: object
-  version: v1alpha2
+              properties:
+                master:
+                  description: |
+                    Master node configuration details.
+                  type: object
+                  properties:
+                    availabilityZone:
+                      description: |
+                        Name of the AWS Availability Zone to place the master node in.
+                      type: string
+                    instanceType:
+                      description: |
+                        EC2 instance type to use for the master node.
+                      type: string
+                region:
+                  description: |
+                    AWS region the cluster is to be running in.
+                  type: string
 `
 
 var awsClusterCRD *apiextensionsv1beta1.CustomResourceDefinition


### PR DESCRIPTION
As pointed out by @paurosello in https://github.com/giantswarm/giantswarm/issues/8804#issuecomment-597517421 the schema for AWSCluster wasn't represented correctly. The reason was bad indentation in the CRD YAML.

This PR fixes that.

The example PR in our docs shows the correct hierarchy:

![image](https://user-images.githubusercontent.com/273727/76401988-10168b80-6383-11ea-8b70-0365e1fc8c68.png)
