### PR TITLE
Fix go vet error with chart DeepCopyTime

### DIFF
--- a/pkg/apis/application/v1alpha1/deep_copy.go
+++ b/pkg/apis/application/v1alpha1/deep_copy.go
@@ -7,7 +7,7 @@ import (
 // DeepCopyTime implements the deep copy logic for time.Time which the k8s
 // codegen is not able to generate out of the box.
 type DeepCopyTime struct {
-	time.Time
+	DeepCopyTime time.Time
 }
 
 func (in *DeepCopyTime) DeepCopyInto(out *DeepCopyTime) {


### PR DESCRIPTION
I'm trying to use `go-build` from architect-orb in https://github.com/giantswarm/chart-operator/pull/374 

But hitting a go vet error `composite literal uses unkeyed fields` with DeepCopyTime. Should I also do the other functions? As we'll hit this in more places eventually.