### PR TITLE
Change example URLs to use gigantic.io domain

### DIFF
--- a/docs/cr/core.giantswarm.io_v1alpha1_ignition.yaml
+++ b/docs/cr/core.giantswarm.io_v1alpha1_ignition.yaml
@@ -7,7 +7,7 @@ metadata:
   name: abc12-master
 spec:
   apiServerEncryptionKey: 5fd466f48df84f47bb8006b68f0355ba
-  baseDomain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+  baseDomain: https://abc12.k8s.example.eu-west-1.aws.gigantic.io
   calico:
     cidr: "16"
     disable: false
@@ -21,7 +21,7 @@ spec:
     networkSetup:
       image: quay.io/giantswarm/k8s-setup-network-environment
   etcd:
-    domain: https://etcd.abc12.k8s.example.eu-west-1.aws.giantswarm.io
+    domain: https://etcd.abc12.k8s.example.eu-west-1.aws.gigantic.io
     port: 2379
     prefix: ""
   extension: {}
@@ -30,15 +30,15 @@ spec:
   isMaster: true
   kubernetes:
     api:
-      domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+      domain: https://abc12.k8s.example.eu-west-1.aws.gigantic.io
       securePort: 443
     cloudProvider: aws
     dns:
       ip: 10.1.2.3/32
-    domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+    domain: https://abc12.k8s.example.eu-west-1.aws.gigantic.io
     ipRange: 10.2.3.4/24
     kubelet:
-      domain: https://abc12.k8s.example.eu-west-1.aws.giantswarm.io
+      domain: https://abc12.k8s.example.eu-west-1.aws.gigantic.io
     oidc:
       clientID: abc12
       enabled: true

--- a/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
+++ b/helm/apiextensions-aws-cluster-config-e2e-chart/values.yaml
@@ -1,6 +1,6 @@
 guest:
   name: "test-cluster"
-  dnsZone: "test-cluster.aws.giantswarm.io"
+  dnsZone: "test-cluster.aws.gigantic.io"
   id: "test-cluster"
   aws:
     instanceTypeMaster: "m5.large"

--- a/pkg/apis/core/v1alpha1/ignition_types_test.go
+++ b/pkg/apis/core/v1alpha1/ignition_types_test.go
@@ -49,7 +49,7 @@ func Test_GenerateIgnitionYAML(t *testing.T) {
 				},
 				Spec: IgnitionSpec{
 					APIServerEncryptionKey: "5fd466f48df84f47bb8006b68f0355ba",
-					BaseDomain:             "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+					BaseDomain:             "https://abc12.k8s.example.eu-west-1.aws.gigantic.io",
 					Calico: IgnitionSpecCalico{
 						CIDR:    "16",
 						Disable: false,
@@ -67,7 +67,7 @@ func Test_GenerateIgnitionYAML(t *testing.T) {
 						},
 					},
 					Etcd: IgnitionSpecEtcd{
-						Domain: "https://etcd.abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+						Domain: "https://etcd.abc12.k8s.example.eu-west-1.aws.gigantic.io",
 						Port:   2379,
 						Prefix: "",
 					},
@@ -82,16 +82,16 @@ func Test_GenerateIgnitionYAML(t *testing.T) {
 					IsMaster: true,
 					Kubernetes: IgnitionSpecKubernetes{
 						API: IgnitionSpecKubernetesAPI{
-							Domain:     "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+							Domain:     "https://abc12.k8s.example.eu-west-1.aws.gigantic.io",
 							SecurePort: 443,
 						},
 						CloudProvider: "aws",
 						DNS: IgnitionSpecKubernetesDNS{
 							IP: "10.1.2.3/32",
 						},
-						Domain: "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+						Domain: "https://abc12.k8s.example.eu-west-1.aws.gigantic.io",
 						Kubelet: IgnitionSpecKubernetesKubelet{
-							Domain: "https://abc12.k8s.example.eu-west-1.aws.giantswarm.io",
+							Domain: "https://abc12.k8s.example.eu-west-1.aws.gigantic.io",
 						},
 						IPRange: "10.2.3.4/24",
 						OIDC: IgnitionSpecOIDC{


### PR DESCRIPTION
For the validation of hyperlinks in our documentation, it would be nice to limit the amount of domains used (and which we can configure an exclusion rule in the link checker for). As I don't want to make an exclusion for `giantswarm.io`, but instead for `gigantic.io`, I am voting for using that domain in the examples, which is the one we actually use in clusters.

To fully explain the problem:

When building docs, the link checker tries to verify URLs like `https://etcd.abc12.k8s.example.eu-west-1.aws.giantswarm.io` and fails. [Example](https://circleci.com/gh/giantswarm/docs/1210?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)