### PR TITLE
Added metrics to the etcd backup CR

### DIFF
--- a/pkg/apis/backup/v1alpha1/etcd_backup_types.go
+++ b/pkg/apis/backup/v1alpha1/etcd_backup_types.go
@@ -51,6 +51,11 @@ spec:
               format: date-time
             instances:
               type: object
+              properties:
+                v1:
+                  type: object
+                v2:
+                  type: object
           required:
           - status
   additionalPrinterColumns:
@@ -129,6 +134,14 @@ type ETCDInstanceBackupStatus struct {
 	FinishedTimestamp DeepCopyTime `json:"finishedTimestamp,omitempty" yaml:"finishedTimestamp"`
 	// Latest backup error message
 	LatestError string `json:"latestError,omitempty" yaml:"latestError,omitempty"`
+	// Time took by the backup creation process
+	CreationTime int64 `json:"creationTime,omitempty" yaml:"creationTime,omitempty"`
+	// Time took by the backup encryption process
+	EncryptionTime int64 `json:"encryptionTime,omitempty" yaml:"encryptionTime,omitempty"`
+	// Time took by the backup upload process
+	UploadTime int64 `json:"uploadTime,omitempty" yaml:"uploadTime,omitempty"`
+	// Size of the backup file
+	BackupFileSize int64 `json:"backupFileSize,omitempty" yaml:"backupFileSize,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Added new fields to the status spec for the etcd-backup type.

Those fields hold some metric information about the backup process that the operator will return to prometheus.