### PR TITLE
Add AWSConfig validation schema

### DIFF
--- a/docs/crd/provider.giantswarm.io_awsconfig.yaml
+++ b/docs/crd/provider.giantswarm.io_awsconfig.yaml
@@ -26,243 +26,459 @@ spec:
           spec:
             properties:
               aws:
+                description: AWS-specific configuration.
                 properties:
                   api:
+                    description: |
+                      Configures the tenant cluster Kubernetes API.
+                      Deprecated since aws-operator v12.
                     properties:
                       elb:
+                        description: |
+                          Configures the Elastic Load Balancer for the
+                          tenant cluster Kubernetes API.
                         properties:
                           idleTimeoutSeconds:
+                            description: |
+                              Seconds to keep an idle connection open.
                             type: int
                         type: object
                       hostedZones:
+                        description: TODO
                         type: string
                     type: object
                   availabilityZones:
+                    description: |
+                      Number of availability zones to use for the tenant cluster's worker nodes.
+                      There are limitations on availability zone settings due to binary IP range
+                      splitting and provider specific region capabilities. When for instance choosing
+                      3 availability zones, the configured IP range will be split into 4 ranges and
+                      thus one of it will not be able to be utilized. Such limitations have to be considered
+                      when designing the network topology and configuring tenant cluster HA via availability
+                      zones.
+
+                      The selection and usage of the actual availability zones for the created
+                      tenant cluster is randomized. In case there are 4 availability zones
+                      provided in the used region and the user selects 2 availability zones, the
+                      actually used availability zones in which tenant cluster workload is put
+                      into will tend to be different across tenant cluster creations. This is
+                      done in order to provide more HA during single availability zone failures.
+                      In case a specific availability zone fails, not all tenant clusters will be
+                      affected due to the described selection process.
                     type: int
                   az:
+                    description: |
+                      Deprecated way to define the availability zone to use
+                      by the tenant cluster.
                     type: string
                   credentialSecret:
+                    description: |
+                      Defines which Secret resource to use in orde to obtain the IAM role to assume
+                      for managing resources for this tenant cluster on AWS. This allows to
+                      run different tenant clusters of the same installation in different
+                      AWS accounts.
                     properties:
                       name:
+                        description: Name of the Secret resource.
                         type: string
                       namespace:
+                        description: Namespace of the Secret resource.
                         type: string
                     type: object
                   etcd:
+                    description: |
+                      Configures the Etcd cluster storing the tenant cluster's data.
+                      Deprecated since aws-operator v12.
                     properties:
                       elb:
+                        description: |
+                          Elastic Load Balancer configuration.
                         properties:
                           idleTimeoutSeconds:
+                            description: |
+                              Seconds to keep an idle connection open.
                             type: int
                         type: object
                       hostedZones:
+                        description: TODO
                         type: string
                     type: object
                   hostedZones:
+                    description: |
+                      HostedZones is AWS hosted zones names in the host cluster account.
+                      For each zone there will be "CLUSTER_ID.k8s" NS record created in
+                      the host cluster account. Then for each created NS record there will
+                      be a zone created in the guest account. After that component-specific
+                      records under those zones:
+
+                      - api.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.API.Name }}
+                      - etcd.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Etcd.Name }}
+                      - ingress.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Ingress.Name }}
+                      - *.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Ingress.Name }}
                     properties:
                       api:
+                        description: |
+                          DNS zone configuration for the Kubernetes API.
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                         type: object
                       etcd:
+                        description: |
+                          DNS zone configuration for Etcd.
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                         type: object
                       ingress:
+                        description: |
+                          DNS zone configuration for Ingress.
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                         type: object
                     type: object
                   ingress:
+                    description: |
+                      Ingress configuration.
+                      Deprecated since aws-operator v12.
                     properties:
                       elb:
+                        description: |
+                          Configuration of the Elastic Load Balancer for Ingress.
                         properties:
                           idleTimeoutSeconds:
+                            description: |
+                              Seconds to keep an idle connection open.
                             type: int
                         type: object
                       hostedZones:
+                        description: TODO
                         type: string
                     type: object
                   masters:
+                    description: |
+                      Configuration of the master nodes.
                     items:
+                      description: |
+                        Configuration for each individual master node.
                       properties:
                         dockerVolumeSizeGB:
+                          description: TODO (appears unused)
                           type: int
                         imageID:
+                          description: |
+                            Amazon Machine Image (AMI) identifier to use as a base for
+                            the EC2 instance of this master node.
                           type: string
                         instanceType:
+                          description: |
+                            Name of the AWS EC2 instance type to use for this master node.
                           type: string
                       type: object
                     type: array
                   region:
+                    description: |
+                      Name of the AWS region the tenant cluster is running in.
                     type: string
                   vpc:
+                    description: |
+                      Configuration of the Virtual Private Cloud (VPC) to use for
+                      the tenant cluster.
                     properties:
                       cidr:
+                        description: TODO
                         type: string
                       peerId:
+                        description: TODO
                         type: string
                       privateSubnetCidr:
+                        description: TODO
                         type: string
                       publicSubnetCidr:
+                        description: TODO
                         type: string
                       routeTableNames:
+                        description: TODO
                         items:
                           type: string
                         type: array
                     type: object
                   workers:
+                    description: |
+                      Configuration of worker nodes.
                     items:
+                      description: |
+                        Configuration of an individual worker node. Each worker node
+                        is represented by one item.
                       properties:
                         dockerVolumeSizeGB:
+                          description: TODO
                           type: int
                         imageID:
+                          description: |
+                            Amazon Machine Image (AMI) identifier to use as a base for
+                            the EC2 instance of this master node.
                           type: string
                         instanceType:
+                          description: |
+                            Name of the AWS EC2 instance type to use for this master node.
                           type: string
                       type: object
                     type: array
                 type: object
               cluster:
+                description: |
+                  Cluster configuration parts that are not meant to be specific to AWS
+                  and thus might look similar or identical on other providers.
                 properties:
                   calico:
+                    description: |
+                      Configuration for the Project Calico Container Network Interface
+                      (CNI).
                     properties:
                       cidr:
+                        description: |
+                          Subnet size, expresses as the count of leading 1 bits in the subnet
+                          mask of this subnet. In other words, in CIDR notation, the integer
+                          behind the slash.
                         type: int
                       mtu:
+                        description: |
+                          Size of the maximum transition unit (MTU) in bytes.
                         type: int
                       subnet:
+                        description: |
+                          Subnet IPv4 address. In other words, in CIDR notation, the
+                          part before the slash.
                         type: string
                     type: object
                   customer:
+                    description: |
+                      Information on the Giant Swarm customer owning the
+                      tenant cluster.
                     properties:
                       id:
+                        description: |
+                          Unique customer identifier.
                         type: string
                     type: object
                   docker:
+                    description: |
+                      Configuration for Docker.
                     properties:
                       daemon:
+                        description: |
+                          Configuration for the Docker daemon.
                         properties:
                           cidr:
+                            description: |
+                              CIDR notation for the subnet to use for Docker
+                              networking.
                             type: string
                         type: object
                     type: object
                   etcd:
+                    description: |
+                      Configuration for Etcd.
                     properties:
                       altNames:
+                        description: TODO
                         type: string
                       domain:
+                        description: |
+                          Domain name to use for Etcd.
                         type: string
                       port:
+                        description: |
+                          Port number Etcd is listening on.
                         type: int
                       prefix:
+                        description: |
+                          Prefix to prepend to all Etcd keys.
                         type: string
                     type: object
                   id:
+                    description: |
+                      Cluster identifier, unique within the installation.
+                      The identifier is expected to be exactly 5 characters
+                      long, with characters from the range a-z and 0-9.
                     type: string
                   kubernetes:
+                    description: |
+                      Various Kubernetes configuration items.
                     properties:
                       api:
+                        description: |
+                          Configuration for the Kubernetes api-server.
                         properties:
                           clusterIPRange:
+                            description: |
+                              IP range to use for ClusterIP, in CIDR notation.
                             type: string
                           domain:
+                            description: |
+                              Fully qualified host name of the API server.
                             type: string
                           securePort:
+                            description: |
+                              Port number for HTTPS access to the API.
                             type: int
                         type: object
                       cloudProvider:
+                        description: Name of the cloud provider. Must be 'aws'.
                         type: string
                       dns:
+                        description: DNS configuration.
                         properties:
                           ip:
+                            description: TODO
                             type: string
                         type: object
                       domain:
+                        description: Domain name to use internally within the cluster.
                         type: string
                       ingressController:
+                        description: |
+                          Configuration of the Ingress Controller.
                         properties:
                           docker:
+                            description: Ingress Controller Docker configuration.
                             properties:
                               image:
+                                description: Docker image for the Ingress Controller.
                                 type: string
                             type: object
                           domain:
+                            description: |
+                              Fully qualified host name the Ingress load balancer is listening on.
                             type: string
                           insecurePort:
+                            description: TODO
                             type: int
                           securePort:
+                            description: TODO
                             type: int
                           wildcardDomain:
+                            description: TODO
                             type: string
                         type: object
                       kubelet:
+                        description: TODO
                         properties:
                           altNames:
+                            description: |
+                              Alternative internal DNS names to access the API server.
                             type: string
                           domain:
+                            description: |
+                              DNS suffix to use for worker nodes.
                             type: string
                           labels:
+                            description: TODO
                             type: string
                           port:
+                            description: TODO
                             type: int
                         type: object
                       networkSetup:
+                        description: TODO
                         properties:
                           docker:
+                            description: TODO
                             properties:
                               image:
+                                description: |
+                                  Docker image for setting up the network environment.
                                 type: string
                             type: object
                           kubeProxy:
+                            description: |
+                              kubeProxy configuration.
                             properties:
                               conntrackMaxPerCore:
+                                description: TODO
                                 type: int
                             type: object
                         type: object
                       ssh:
+                        description: |
+                          SSH access configuration applied to master and worker nodes
+                          of the tenant cluster.
                         properties:
                           userList:
+                            description: |
+                              List of SSH users with access to the nodes.
                             items:
+                              description: |
+                                An individual SSH user with access.
                               properties:
                                 name:
+                                  description: |
+                                    Posix username to assign to the user logging in with
+                                    the given SSH public key.
                                   type: string
                                 publicKey:
+                                  description: |
+                                    SSH public key in Base64 encoding.
                                   type: string
                               type: object
                             type: array
                         type: object
                     type: object
                   masters:
+                    description: |
+                      Configuration of master nodes.
                     items:
+                      description: TODO
                       properties:
                         id:
+                          description: TODO
                           type: string
                       type: object
                     type: array
                   scaling:
+                    description: |
+                      Configuration of worker node scaling. The cluster-autoscaler
+                      sets the actual number of worker nodes in the cluster based
+                      on the 'min' and 'max' value.
                     properties:
                       max:
+                        description: |
+                          Maximum amount of worker nodes. Upper limit of the
+                          autoscaling range.
                         type: int
                       min:
+                        description: |
+                          Minimum amount of worker nodes. Lower limit of the
+                          autoscaling range.
                         type: int
                     type: object
                   version:
+                    description: TODO
                     type: string
                   workers:
+                    description: |
+                      List of worker nodes with configuration.
                     items:
+                      description: |
+                        Configuration of an individual worker node.
                       properties:
                         id:
+                          description: |
+                            Unique identifier of the worker node.
                           type: string
                       type: object
                     type: array
                 type: object
               versionBundle:
+                description: TODO
                 properties:
                   version:
+                    description: TODO
                     type: string
                 type: object
             type: object

--- a/docs/crd/provider.giantswarm.io_awsconfig.yaml
+++ b/docs/crd/provider.giantswarm.io_awsconfig.yaml
@@ -16,6 +16,257 @@ spec:
   scope: Namespaced
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |
+          Together with AWSClusterConfig, defines a tenant cluster in a
+          Giant Swarm installation in releases before v10.0.1.
+          Reconciled by aws-operator.
+        properties:
+          spec:
+            properties:
+              aws:
+                properties:
+                  api:
+                    properties:
+                      elb:
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                        type: object
+                      hostedZones:
+                        type: string
+                    type: object
+                  availabilityZones:
+                    type: int
+                  az:
+                    type: string
+                  credentialSecret:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  etcd:
+                    properties:
+                      elb:
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                        type: object
+                      hostedZones:
+                        type: string
+                    type: object
+                  hostedZones:
+                    properties:
+                      api:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      etcd:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      ingress:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                    type: object
+                  ingress:
+                    properties:
+                      elb:
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                        type: object
+                      hostedZones:
+                        type: string
+                    type: object
+                  masters:
+                    items:
+                      properties:
+                        dockerVolumeSizeGB:
+                          type: int
+                        imageID:
+                          type: string
+                        instanceType:
+                          type: string
+                      type: object
+                    type: array
+                  region:
+                    type: string
+                  vpc:
+                    properties:
+                      cidr:
+                        type: string
+                      peerId:
+                        type: string
+                      privateSubnetCidr:
+                        type: string
+                      publicSubnetCidr:
+                        type: string
+                      routeTableNames:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  workers:
+                    items:
+                      properties:
+                        dockerVolumeSizeGB:
+                          type: int
+                        imageID:
+                          type: string
+                        instanceType:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              cluster:
+                properties:
+                  calico:
+                    properties:
+                      cidr:
+                        type: int
+                      mtu:
+                        type: int
+                      subnet:
+                        type: string
+                    type: object
+                  customer:
+                    properties:
+                      id:
+                        type: string
+                    type: object
+                  docker:
+                    properties:
+                      daemon:
+                        properties:
+                          cidr:
+                            type: string
+                        type: object
+                    type: object
+                  etcd:
+                    properties:
+                      altNames:
+                        type: string
+                      domain:
+                        type: string
+                      port:
+                        type: int
+                      prefix:
+                        type: string
+                    type: object
+                  id:
+                    type: string
+                  kubernetes:
+                    properties:
+                      api:
+                        properties:
+                          clusterIPRange:
+                            type: string
+                          domain:
+                            type: string
+                          securePort:
+                            type: int
+                        type: object
+                      cloudProvider:
+                        type: string
+                      dns:
+                        properties:
+                          ip:
+                            type: string
+                        type: object
+                      domain:
+                        type: string
+                      ingressController:
+                        properties:
+                          docker:
+                            properties:
+                              image:
+                                type: string
+                            type: object
+                          domain:
+                            type: string
+                          insecurePort:
+                            type: int
+                          securePort:
+                            type: int
+                          wildcardDomain:
+                            type: string
+                        type: object
+                      kubelet:
+                        properties:
+                          altNames:
+                            type: string
+                          domain:
+                            type: string
+                          labels:
+                            type: string
+                          port:
+                            type: int
+                        type: object
+                      networkSetup:
+                        properties:
+                          docker:
+                            properties:
+                              image:
+                                type: string
+                            type: object
+                          kubeProxy:
+                            properties:
+                              conntrackMaxPerCore:
+                                type: int
+                            type: object
+                        type: object
+                      ssh:
+                        properties:
+                          userList:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                publicKey:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  masters:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                      type: object
+                    type: array
+                  scaling:
+                    properties:
+                      max:
+                        type: int
+                      min:
+                        type: int
+                    type: object
+                  version:
+                    type: string
+                  workers:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              versionBundle:
+                properties:
+                  version:
+                    type: string
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
     subresources:

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -36,6 +36,257 @@ spec:
     storage: true
     subresources:
       status: {}
+    schema:
+      openAPIV3Schema:
+        description: |
+          Together with AWSClusterConfig, defines a tenant cluster in a
+          Giant Swarm installation in releases before v10.0.1.
+          Reconciled by aws-operator.
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              aws:
+                type: object
+                properties:
+                  api:
+                    type: object
+                    properties:
+                      elb:
+                        type: object
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                      hostedZones:
+                        type: string
+                  availabilityZones:
+                    type: int
+                  az:
+                    type: string
+                  credentialSecret:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  etcd:
+                    type: object
+                    properties:
+                      elb:
+                        type: object
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                      hostedZones:
+                        type: string
+                  hostedZones:
+                    type: object
+                    properties:
+                      api:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      etcd:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      ingress:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                  ingress:
+                    type: object
+                    properties:
+                      elb:
+                        type: object
+                        properties:
+                          idleTimeoutSeconds:
+                            type: int
+                      hostedZones:
+                        type: string
+                  masters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        dockerVolumeSizeGB:
+                          type: int
+                        imageID:
+                          type: string
+                        instanceType:
+                          type: string
+                  region:
+                    type: string
+                  vpc:
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      peerId:
+                        type: string
+                      privateSubnetCidr:
+                        type: string
+                      publicSubnetCidr:
+                        type: string
+                      routeTableNames:
+                        type: array
+                        items:
+                          type: string
+                  workers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        dockerVolumeSizeGB:
+                          type: int
+                        imageID:
+                          type: string
+                        instanceType:
+                          type: string
+              cluster:
+                type: object
+                properties:
+                  calico:
+                    type: object
+                    properties:
+                      cidr:
+                        type: int
+                      mtu:
+                        type: int
+                      subnet:
+                        type: string
+                  customer:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  docker:
+                    type: object
+                    properties:
+                      daemon:
+                        type: object
+                        properties:
+                          cidr:
+                            type: string
+                  etcd:
+                    type: object
+                    properties:
+                      altNames:
+                        type: string
+                      domain:
+                        type: string
+                      port:
+                        type: int
+                      prefix:
+                        type: string
+                  id:
+                    type: string
+                  kubernetes:
+                    type: object
+                    properties:
+                      api:
+                        type: object
+                        properties:
+                          clusterIPRange:
+                            type: string
+                          domain:
+                            type: string
+                          securePort:
+                            type: int
+                      cloudProvider:
+                        type: string
+                      dns:
+                        type: object
+                        properties:
+                          ip:
+                            type: string
+                      domain:
+                        type: string
+                      ingressController:
+                        type: object
+                        properties:
+                          docker:
+                            type: object
+                            properties:
+                              image:
+                                type: string
+                          domain:
+                            type: string
+                          insecurePort:
+                            type: int
+                          securePort:
+                            type: int
+                          wildcardDomain:
+                            type: string
+                      kubelet:
+                        type: object
+                        properties:
+                          altNames:
+                            type: string
+                          domain:
+                            type: string
+                          labels:
+                            type: string
+                          port:
+                            type: int
+                      networkSetup:
+                        type: object
+                        properties:
+                          docker:
+                            type: object
+                            properties:
+                              image:
+                                type: string
+                          kubeProxy:
+                            type: object
+                            properties:
+                              conntrackMaxPerCore:
+                                type: int
+                      ssh:
+                        type: object
+                        properties:
+                          userList:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                publicKey:
+                                  type: string
+                  masters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                  scaling:
+                    type: object
+                    properties:
+                      min:
+                        type: int
+                      max:
+                        type: int
+                  version:
+                    type: string
+                  workers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+              versionBundle:
+                type: object
+                properties:
+                  version:
+                    type: string
 `
 
 var awsConfigCRD *apiextensionsv1beta1.CustomResourceDefinition

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -331,48 +331,55 @@ spec:
                       long, with characters from the range a-z and 0-9.
                     type: string
                   kubernetes:
-                    description: TODO
+                    description: |
+                      Various Kubernetes configuration items.
                     type: object
                     properties:
                       api:
-                        description: TODO
+                        description: |
+                          Configuration for the Kubernetes api-server.
                         type: object
                         properties:
                           clusterIPRange:
-                            description: TODO
+                            description: |
+                              IP range to use for ClusterIP, in CIDR notation.
                             type: string
                           domain:
-                            description: TODO
+                            description: |
+                              Fully qualified host name of the API server.
                             type: string
                           securePort:
-                            description: TODO
+                            description: |
+                              Port number for HTTPS access to the API.
                             type: int
                       cloudProvider:
-                        description: TODO
+                        description: Name of the cloud provider. Must be 'aws'.
                         type: string
                       dns:
-                        description: TODO
+                        description: DNS configuration.
                         type: object
                         properties:
                           ip:
                             description: TODO
                             type: string
                       domain:
-                        description: TODO
+                        description: Domain name to use internally within the cluster.
                         type: string
                       ingressController:
-                        description: TODO
+                        description: |
+                          Configuration of the Ingress Controller.
                         type: object
                         properties:
                           docker:
-                            description: TODO
+                            description: Ingress Controller Docker configuration.
                             type: object
                             properties:
                               image:
-                                description: TODO
+                                description: Docker image for the Ingress Controller.
                                 type: string
                           domain:
-                            description: TODO
+                            description: |
+                              Fully qualified host name the Ingress load balancer is listening on.
                             type: string
                           insecurePort:
                             description: TODO
@@ -388,10 +395,12 @@ spec:
                         type: object
                         properties:
                           altNames:
-                            description: TODO
+                            description: |
+                              Alternative internal DNS names to access the API server.
                             type: string
                           domain:
-                            description: TODO
+                            description: |
+                              DNS suffix to use for worker nodes.
                             type: string
                           labels:
                             description: TODO
@@ -408,34 +417,44 @@ spec:
                             type: object
                             properties:
                               image:
-                                description: TODO
+                                description: |
+                                  Docker image for setting up the network environment.
                                 type: string
                           kubeProxy:
-                            description: TODO
+                            description: |
+                              kubeProxy configuration.
                             type: object
                             properties:
                               conntrackMaxPerCore:
                                 description: TODO
                                 type: int
                       ssh:
-                        description: TODO
+                        description: |
+                          SSH access configuration applied to master and worker nodes
+                          of the tenant cluster.
                         type: object
                         properties:
                           userList:
-                            description: TODO
+                            description: |
+                              List of SSH users with access to the nodes.
                             type: array
                             items:
-                              description: TODO
+                              description: |
+                                An individual SSH user with access.
                               type: object
                               properties:
                                 name:
-                                  description: TODO
+                                  description: |
+                                    Posix username to assign to the user logging in with
+                                    the given SSH public key.
                                   type: string
                                 publicKey:
-                                  description: TODO
+                                  description: |
+                                    SSH public key in Base64 encoding.
                                   type: string
                   masters:
-                    description: TODO
+                    description: |
+                      Configuration of master nodes.
                     type: array
                     items:
                       description: TODO
@@ -445,27 +464,37 @@ spec:
                           description: TODO
                           type: string
                   scaling:
-                    description: TODO
+                    description: |
+                      Configuration of worker node scaling. The cluster-autoscaler
+                      sets the actual number of worker nodes in the cluster based
+                      on the 'min' and 'max' value.
                     type: object
                     properties:
                       min:
-                        description: TODO
+                        description: |
+                          Minimum amount of worker nodes. Lower limit of the
+                          autoscaling range.
                         type: int
                       max:
-                        description: TODO
+                        description: |
+                          Maximum amount of worker nodes. Upper limit of the
+                          autoscaling range.
                         type: int
                   version:
                     description: TODO
                     type: string
                   workers:
-                    description: TODO
+                    description: |
+                      List of worker nodes with configuration.
                     type: array
                     items:
-                      description: TODO
+                      description: |
+                        Configuration of an individual worker node.
                       type: object
                       properties:
                         id:
-                          description: TODO
+                          description: |
+                            Unique identifier of the worker node.
                           type: string
               versionBundle:
                 description: TODO

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -48,244 +48,431 @@ spec:
             type: object
             properties:
               aws:
+                description: AWS-specific configuration.
                 type: object
                 properties:
                   api:
+                    description: |
+                      Configures the tenant cluster Kubernetes API.
+                      Deprecated since aws-operator v12.
                     type: object
                     properties:
                       elb:
+                        description: |
+                          Configures the Elastic Load Balancer for the
+                          tenant cluster Kubernetes API.
                         type: object
                         properties:
                           idleTimeoutSeconds:
+                            description: |
+                              Seconds to keep an idle connection open.
                             type: int
                       hostedZones:
+                        description: TODO
                         type: string
                   availabilityZones:
+                    description: |
+                      Number of availability zones to use for the tenant cluster's worker nodes.
+                      There are limitations on availability zone settings due to binary IP range
+                      splitting and provider specific region capabilities. When for instance choosing
+                      3 availability zones, the configured IP range will be split into 4 ranges and
+                      thus one of it will not be able to be utilized. Such limitations have to be considered
+                      when designing the network topology and configuring tenant cluster HA via availability
+                      zones.
+
+                      The selection and usage of the actual availability zones for the created
+                      tenant cluster is randomized. In case there are 4 availability zones
+                      provided in the used region and the user selects 2 availability zones, the
+                      actually used availability zones in which tenant cluster workload is put
+                      into will tend to be different across tenant cluster creations. This is
+                      done in order to provide more HA during single availability zone failures.
+                      In case a specific availability zone fails, not all tenant clusters will be
+                      affected due to the described selection process.
                     type: int
                   az:
+                    description: |
+                      Deprecated way to define the availability zone to use
+                      by the tenant cluster.
                     type: string
                   credentialSecret:
+                    description: |
+                      Defines which Secret resource to use in orde to obtain the IAM role to assume
+                      for managing resources for this tenant cluster on AWS. This allows to
+                      run different tenant clusters of the same installation in different
+                      AWS accounts.
                     type: object
                     properties:
                       name:
+                        description: Name of the Secret resource.
                         type: string
                       namespace:
+                        description: Namespace of the Secret resource.
                         type: string
                   etcd:
+                    description: |
+                      Configures the Etcd cluster storing the tenant cluster's data.
+                      Deprecated since aws-operator v12.
                     type: object
                     properties:
                       elb:
+                        description: |
+                          Elastic Load Balancer configuration.
                         type: object
                         properties:
                           idleTimeoutSeconds:
+                            description:  |
+                              Seconds to keep an idle connection open.
                             type: int
                       hostedZones:
+                        description: TODO
                         type: string
                   hostedZones:
+                    description: |
+                      HostedZones is AWS hosted zones names in the host cluster account.
+                      For each zone there will be "CLUSTER_ID.k8s" NS record created in
+                      the host cluster account. Then for each created NS record there will
+                      be a zone created in the guest account. After that component-specific
+                      records under those zones:
+
+                      - api.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.API.Name }}
+                      - etcd.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Etcd.Name }}
+                      - ingress.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Ingress.Name }}
+                      - *.CLUSTER_ID.k8s.{{ .Spec.AWS.HostedZones.Ingress.Name }}
                     type: object
                     properties:
                       api:
+                        description: |
+                          DNS zone configuration for the Kubernetes API.
                         type: object
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                       etcd:
+                        description: |
+                          DNS zone configuration for Etcd.
                         type: object
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                       ingress:
+                        description: |
+                          DNS zone configuration for Ingress.
                         type: object
                         properties:
                           name:
+                            description: Zone name.
                             type: string
                   ingress:
+                    description: |
+                      Ingress configuration.
+                      Deprecated since aws-operator v12.
                     type: object
                     properties:
                       elb:
+                        description: |
+                          Configuration of the Elastic Load Balancer for Ingress.
                         type: object
                         properties:
                           idleTimeoutSeconds:
+                            description:  |
+                              Seconds to keep an idle connection open.
                             type: int
                       hostedZones:
+                        description: TODO
                         type: string
                   masters:
+                    description: |
+                      Configuration of the master nodes.
                     type: array
                     items:
+                      description: |
+                        Configuration for each individual master node.
                       type: object
                       properties:
                         dockerVolumeSizeGB:
+                          description: TODO (appears unused)
                           type: int
                         imageID:
+                          description: |
+                            Amazon Machine Image (AMI) identifier to use as a base for
+                            the EC2 instance of this master node.
                           type: string
                         instanceType:
+                          description: |
+                            Name of the AWS EC2 instance type to use for this master node.
                           type: string
                   region:
+                    description: |
+                      Name of the AWS region the tenant cluster is running in.
                     type: string
                   vpc:
+                    description: |
+                      Configuration of the Virtual Private Cloud (VPC) to use for
+                      the tenant cluster.
                     type: object
                     properties:
                       cidr:
+                        description: TODO
                         type: string
                       peerId:
+                        description: TODO
                         type: string
                       privateSubnetCidr:
+                        description: TODO
                         type: string
                       publicSubnetCidr:
+                        description: TODO
                         type: string
                       routeTableNames:
+                        description: TODO
                         type: array
                         items:
                           type: string
                   workers:
+                    description: |
+                      Configuration of worker nodes.
                     type: array
                     items:
+                      description: |
+                        Configuration of an individual worker node. Each worker node
+                        is represented by one item.
                       type: object
                       properties:
                         dockerVolumeSizeGB:
+                          description: TODO
                           type: int
                         imageID:
+                          description: |
+                            Amazon Machine Image (AMI) identifier to use as a base for
+                            the EC2 instance of this master node.
                           type: string
                         instanceType:
+                          description: |
+                            Name of the AWS EC2 instance type to use for this master node.
                           type: string
               cluster:
+                description: |
+                  Cluster configuration parts that are not meant to be specific to AWS
+                  and thus might look similar or identical on other providers.
                 type: object
                 properties:
                   calico:
+                    description: |
+                      Configuration for the Project Calico Container Network Interface
+                      (CNI).
                     type: object
                     properties:
                       cidr:
+                        description: |
+                          Subnet size, expresses as the count of leading 1 bits in the subnet
+                          mask of this subnet. In other words, in CIDR notation, the integer
+                          behind the slash.
                         type: int
                       mtu:
+                        description: |
+                          Size of the maximum transition unit (MTU) in bytes.
                         type: int
                       subnet:
+                        description: |
+                          Subnet IPv4 address. In other words, in CIDR notation, the
+                          part before the slash.
                         type: string
                   customer:
+                    description: |
+                      Information on the Giant Swarm customer owning the
+                      tenant cluster.
                     type: object
                     properties:
                       id:
+                        description: |
+                          Unique customer identifier.
                         type: string
                   docker:
+                    description: |
+                      Configuration for Docker.
                     type: object
                     properties:
                       daemon:
+                        description: |
+                          Configuration for the Docker daemon.
                         type: object
                         properties:
                           cidr:
+                            description: |
+                              CIDR notation for the subnet to use for Docker
+                              networking.
                             type: string
                   etcd:
+                    description: |
+                      Configuration for Etcd.
                     type: object
                     properties:
                       altNames:
+                        description: TODO
                         type: string
                       domain:
+                        description: |
+                          Domain name to use for Etcd.
                         type: string
                       port:
+                        description: |
+                          Port number Etcd is listening on.
                         type: int
                       prefix:
+                        description: |
+                          Prefix to prepend to all Etcd keys.
                         type: string
                   id:
+                    description: |
+                      Cluster identifier, unique within the installation.
+                      The identifier is expected to be exactly 5 characters
+                      long, with characters from the range a-z and 0-9.
                     type: string
                   kubernetes:
+                    description: TODO
                     type: object
                     properties:
                       api:
+                        description: TODO
                         type: object
                         properties:
                           clusterIPRange:
+                            description: TODO
                             type: string
                           domain:
+                            description: TODO
                             type: string
                           securePort:
+                            description: TODO
                             type: int
                       cloudProvider:
+                        description: TODO
                         type: string
                       dns:
+                        description: TODO
                         type: object
                         properties:
                           ip:
+                            description: TODO
                             type: string
                       domain:
+                        description: TODO
                         type: string
                       ingressController:
+                        description: TODO
                         type: object
                         properties:
                           docker:
+                            description: TODO
                             type: object
                             properties:
                               image:
+                                description: TODO
                                 type: string
                           domain:
+                            description: TODO
                             type: string
                           insecurePort:
+                            description: TODO
                             type: int
                           securePort:
+                            description: TODO
                             type: int
                           wildcardDomain:
+                            description: TODO
                             type: string
                       kubelet:
+                        description: TODO
                         type: object
                         properties:
                           altNames:
+                            description: TODO
                             type: string
                           domain:
+                            description: TODO
                             type: string
                           labels:
+                            description: TODO
                             type: string
                           port:
+                            description: TODO
                             type: int
                       networkSetup:
+                        description: TODO
                         type: object
                         properties:
                           docker:
+                            description: TODO
                             type: object
                             properties:
                               image:
+                                description: TODO
                                 type: string
                           kubeProxy:
+                            description: TODO
                             type: object
                             properties:
                               conntrackMaxPerCore:
+                                description: TODO
                                 type: int
                       ssh:
+                        description: TODO
                         type: object
                         properties:
                           userList:
+                            description: TODO
                             type: array
                             items:
+                              description: TODO
                               type: object
                               properties:
                                 name:
+                                  description: TODO
                                   type: string
                                 publicKey:
+                                  description: TODO
                                   type: string
                   masters:
+                    description: TODO
                     type: array
                     items:
+                      description: TODO
                       type: object
                       properties:
                         id:
+                          description: TODO
                           type: string
                   scaling:
+                    description: TODO
                     type: object
                     properties:
                       min:
+                        description: TODO
                         type: int
                       max:
+                        description: TODO
                         type: int
                   version:
+                    description: TODO
                     type: string
                   workers:
+                    description: TODO
                     type: array
                     items:
+                      description: TODO
                       type: object
                       properties:
                         id:
+                          description: TODO
                           type: string
               versionBundle:
+                description: TODO
                 type: object
                 properties:
                   version:
+                    description: TODO
                     type: string
 `
 


### PR DESCRIPTION
Based on and to be merged into https://github.com/giantswarm/apiextensions/pull/372

This adds the OpenAPIv3 validation schema for the AWSConfig CRD.