### PR TITLE
Document MachineDeployment CRD

### DIFF
--- a/docs/cr/infrastructure.giantswarm.io_v1alpha2_machinedeployment.yaml
+++ b/docs/cr/infrastructure.giantswarm.io_v1alpha2_machinedeployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: MachineDeployment
+metadata:
+  annotations:
+    giantswarm.io/docs: https://pkg.go.dev/sigs.k8s.io/cluster-api/api/v1alpha2?tab=doc#MachineDeployment
+  creationTimestamp: null
+  name: e3z8q
+spec:
+  replicas: 10
+  selector: {}
+  template:
+    metadata: {}
+    spec:
+      bootstrap: {}
+      infrastructureRef:
+        apiVersion: infrastructure.giantswarm.io/v1alpha2
+        kind: AWSMachineDeployment
+        name: e3z8q
+        namespace: default
+        resourceVersion: "58776588"
+        uid: b5fdf153-6f10-462b-a49f-0e821873d16b
+      metadata: {}

--- a/docs/crd/infrastructure.giantswarm.io_machinedeployment.yaml
+++ b/docs/crd/infrastructure.giantswarm.io_machinedeployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: cluster.x-k8s.io
+  names:
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    singular: machinedeployment
+  preserveUnknownFields: true
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/infrastructure/v1alpha2/cluster_api_crds.go
+++ b/pkg/apis/infrastructure/v1alpha2/cluster_api_crds.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	kindCluster                        = "Cluster"
+	kindMachineDeployment              = "MachineDeployment"
 	clusterDocumentationLink           = "https://pkg.go.dev/sigs.k8s.io/cluster-api/api/v1alpha2?tab=doc#Cluster"
 	machineDeploymentDocumentationLink = "https://pkg.go.dev/sigs.k8s.io/cluster-api/api/v1alpha2?tab=doc#MachineDeployment"
 )
@@ -148,4 +149,24 @@ func NewClusterCR() *apiv1alpha2.Cluster {
 //
 func NewMachineDeploymentCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return machineDeploymentCRD.DeepCopy()
+}
+
+// NewMachineDeploymentTypeMeta returns the type block for a MachineDeployment CR.
+func NewMachineDeploymentTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: SchemeGroupVersion.String(),
+		Kind:       kindMachineDeployment,
+	}
+}
+
+// NewMachineDeploymentCR returns a MachineDeployment Custom Resource.
+func NewMachineDeploymentCR() *apiv1alpha2.MachineDeployment {
+	return &apiv1alpha2.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				crDocsAnnotation: machineDeploymentDocumentationLink,
+			},
+		},
+		TypeMeta: NewMachineDeploymentTypeMeta(),
+	}
 }

--- a/pkg/apis/infrastructure/v1alpha2/cluster_api_crds_test.go
+++ b/pkg/apis/infrastructure/v1alpha2/cluster_api_crds_test.go
@@ -95,3 +95,93 @@ func newClusterExampleCR() *apiv1alpha2.Cluster {
 
 	return cr
 }
+
+func Test_NewMachineDeploymentCRD(t *testing.T) {
+	crd := NewMachineDeploymentCRD()
+	if crd == nil {
+		t.Error("MachineDeployment CRD was nil.")
+	}
+	if crd.Name == "" {
+		t.Error("MachineDeployment CRD name was empty.")
+	}
+}
+
+func Test_GenerateMachineDeploymentYAML(t *testing.T) {
+	testCases := []struct {
+		category string
+		name     string
+		resource runtime.Object
+	}{
+		{
+			category: "crd",
+			name:     fmt.Sprintf("%s_machinedeployment.yaml", group),
+			resource: NewMachineDeploymentCRD(),
+		},
+		{
+			category: "cr",
+			name:     fmt.Sprintf("%s_%s_machinedeployment.yaml", group, version),
+			resource: newMachineDeploymentExampleCR(),
+		},
+	}
+
+	docs := filepath.Join(root, "..", "..", "..", "..", "docs")
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: generates %s successfully", i, tc.name), func(t *testing.T) {
+			rendered, err := yaml.Marshal(tc.resource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			directory := filepath.Join(docs, tc.category)
+			path := filepath.Join(directory, tc.name)
+
+			// We don't want a status in the docs YAML for the CR and CRD so that they work with `kubectl create -f <file>.yaml`.
+			// This just strips off the top level `status:` and everything following.
+			statusRegex := regexp.MustCompile(`(?ms)^status:.*$`)
+			rendered = statusRegex.ReplaceAll(rendered, []byte(""))
+
+			if *update {
+				err := ioutil.WriteFile(path, rendered, 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			goldenFile, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(rendered, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(rendered)))
+			}
+		})
+	}
+}
+
+func newMachineDeploymentExampleCR() *apiv1alpha2.MachineDeployment {
+	cr := NewMachineDeploymentCR()
+
+	ten := int32(10)
+
+	cr.Name = "e3z8q"
+	cr.Spec = apiv1alpha2.MachineDeploymentSpec{
+		Replicas: &ten,
+		Template: apiv1alpha2.MachineTemplateSpec{
+			Spec: apiv1alpha2.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion:      "infrastructure.giantswarm.io/v1alpha2",
+					Kind:            "AWSMachineDeployment",
+					Name:            "e3z8q",
+					Namespace:       "default",
+					ResourceVersion: "58776588",
+					UID:             "b5fdf153-6f10-462b-a49f-0e821873d16b",
+				},
+			},
+		},
+	}
+	cr.Status = apiv1alpha2.MachineDeploymentStatus{
+		ReadyReplicas: 8,
+		Replicas:      10,
+	}
+
+	return cr
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

Based on https://github.com/giantswarm/apiextensions/pull/375 and to be merged into `cluster-docs`.

Changes

1. Makes CRD initialized from YAML string
2. Create CR and CRD files in docs folder via unit tests

As in https://github.com/giantswarm/apiextensions/pull/375 there is an open question regarding the file name schema in the docs folder.