### PR TITLE
Add third AZ to AWSControlPlane example

### DIFF
--- a/docs/cr/infrastructure.giantswarm.io_v1alpha2_awscontrolplane.yaml
+++ b/docs/cr/infrastructure.giantswarm.io_v1alpha2_awscontrolplane.yaml
@@ -8,5 +8,6 @@ metadata:
 spec:
   availabilityZones:
   - eu-central-1a
+  - eu-central-1b
   - eu-central-1c
   instanceType: m4.xlarge

--- a/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types_test.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types_test.go
@@ -81,6 +81,7 @@ func newAWSControlPlaneExampleCR() *AWSControlPlane {
 	cr.Spec = AWSControlPlaneSpec{
 		AvailabilityZones: []string{
 			"eu-central-1a",
+			"eu-central-1b",
 			"eu-central-1c",
 		},
 		InstanceType: "m4.xlarge",


### PR DESCRIPTION
I figured that the example I crafted would be invalid according to our own description.