### PR TITLE
make oidc fields omitempty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
           command: build
           requires:
             - go-test
+
       - architect/go-architect-legacy:
           name: go-deploy
           command: deploy

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -203,7 +203,7 @@ type AWSClusterSpecCluster struct {
 	// DNS holds DNS configuration details.
 	DNS AWSClusterSpecClusterDNS `json:"dns" yaml:"dns"`
 	// OIDC holds configuration for OpenID Connect (OIDC) authentication.
-	OIDC AWSClusterSpecClusterOIDC `json:"oidc" yaml:"oidc"`
+	OIDC AWSClusterSpecClusterOIDC `json:"oidc,omitempty" yaml:"oidc,omitempty"`
 }
 
 // AWSClusterSpecClusterDNS holds DNS configuration details.
@@ -213,15 +213,15 @@ type AWSClusterSpecClusterDNS struct {
 
 // AWSClusterSpecClusterOIDC holds configuration for OpenID Connect (OIDC) authentication.
 type AWSClusterSpecClusterOIDC struct {
-	Claims    AWSClusterSpecClusterOIDCClaims `json:"claims" yaml:"claims"`
-	ClientID  string                          `json:"clientID" yaml:"clientID"`
-	IssuerURL string                          `json:"issuerURL" yaml:"issuerURL"`
+	Claims    AWSClusterSpecClusterOIDCClaims `json:"claims,omitempty" yaml:"claims,omitempty"`
+	ClientID  string                          `json:"clientID,omitempty" yaml:"clientID,omitempty"`
+	IssuerURL string                          `json:"issuerURL,omitempty" yaml:"issuerURL,omitempty"`
 }
 
 // AWSClusterSpecClusterOIDCClaims defines OIDC claims.
 type AWSClusterSpecClusterOIDCClaims struct {
-	Username string `json:"username" yaml:"username"`
-	Groups   string `json:"groups" yaml:"groups"`
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Groups   string `json:"groups,omitempty" yaml:"groups,omitempty"`
 }
 
 // AWSClusterSpecProvider holds some AWS details.


### PR DESCRIPTION
Just a little cosmetic. It looks like this in a lot of places. 

```
    oidc:
      claims:
        groups: ""
        username: ""
      clientID: ""
      issuerURL: ""
```

With this PR it is like this. 

```
    oidc:
      claims: {}
```