### PR TITLE
Prepare CertConfig for schema documentation

### DIFF
--- a/docs/cr/core.giantswarm.io_v1alpha1_certconfig.yaml
+++ b/docs/cr/core.giantswarm.io_v1alpha1_certconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: core.giantswarm.io/v1alpha1
+kind: CertConfig
+metadata:
+  annotations:
+    giantswarm.io/docs: https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1?tab=doc#CertConfig
+  creationTimestamp: null
+  name: c68pn-prometheus
+spec:
+  cert:
+    allowBareDomains: false
+    altNames: []
+    clusterComponent: prometheus
+    clusterID: c68pn
+    commonName: api.c68pn.k8s.gollum.westeurope.azure.gigantic.io
+    disableRegeneration: false
+    ipSans: []
+    organizations: []
+    ttl: 4320h
+  versionBundle:
+    version: 0.1.0

--- a/docs/crd/core.giantswarm.io_certconfig.yaml
+++ b/docs/crd/core.giantswarm.io_certconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: certconfigs.core.giantswarm.io
+spec:
+  conversion:
+    strategy: None
+  group: core.giantswarm.io
+  names:
+    kind: CertConfig
+    listKind: CertConfigList
+    plural: certconfigs
+    singular: certconfig
+  preserveUnknownFields: true
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/pkg/apis/core/v1alpha1/cert_types.go
+++ b/pkg/apis/core/v1alpha1/cert_types.go
@@ -3,30 +3,50 @@ package v1alpha1
 import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
+const (
+	crDocsAnnotation            = "giantswarm.io/docs"
+	kindCertConfig              = "CertConfig"
+	certConfigDocumentationLink = "https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1?tab=doc#CertConfig"
+)
+
+const certConfigCRDYAML = `
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certconfigs.core.giantswarm.io
+spec:
+  conversion:
+    strategy: None
+  group: core.giantswarm.io
+  names:
+    kind: CertConfig
+    listKind: CertConfigList
+    plural: certconfigs
+    singular: certconfig
+  preserveUnknownFields: true
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+`
+
+var certConfigCRD *apiextensionsv1beta1.CustomResourceDefinition
+
+func init() {
+	err := yaml.Unmarshal([]byte(certConfigCRDYAML), &certConfigCRD)
+	if err != nil {
+		panic(err)
+	}
+}
+
 // NewCertConfigCRD returns a new custom resource definition for CertConfig.
-// This might look something like the following.
-//
-//     apiVersion: apiextensions.k8s.io/v1beta1
-//     kind: CustomResourceDefinition
-//     metadata:
-//       name: certconfigs.core.giantswarm.io
-//     spec:
-//       group: core.giantswarm.io
-//       scope: Namespaced
-//       version: v1alpha1
-//       names:
-//         kind: CertConfig
-//         plural: certconfigs
-//         singular: certconfig
-//
 func NewCertConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: apiextensionsv1beta1.SchemeGroupVersion.String(),
-			Kind:       "CustomResourceDefinition",
-		},
+	return certConfigCRD.DeepCopy()
+}
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "certconfigs.core.giantswarm.io",
 		},

--- a/pkg/apis/core/v1alpha1/cert_types.go
+++ b/pkg/apis/core/v1alpha1/cert_types.go
@@ -47,19 +47,25 @@ func init() {
 func NewCertConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 	return certConfigCRD.DeepCopy()
 }
+
+// NewCertConfigTypeMeta returns the type part for the metadata section of a
+// CertConfig custom resource.
+func NewCertConfigTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: SchemeGroupVersion.String(),
+		Kind:       kindCertConfig,
+	}
+}
+
+// NewCertConfigCR returns an AWSCluster Custom Resource.
+func NewCertConfigCR() *CertConfig {
+	return &CertConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "certconfigs.core.giantswarm.io",
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "core.giantswarm.io",
-			Scope:   "Namespaced",
-			Version: "v1alpha1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Kind:     "CertConfig",
-				Plural:   "certconfigs",
-				Singular: "certconfig",
+			Annotations: map[string]string{
+				crDocsAnnotation: certConfigDocumentationLink,
 			},
 		},
+		TypeMeta: NewCertConfigTypeMeta(),
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/cert_types_test.go
+++ b/pkg/apis/core/v1alpha1/cert_types_test.go
@@ -1,0 +1,99 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+)
+
+func Test_CertConfigCRD(t *testing.T) {
+	crd := NewCertConfigCRD()
+	if crd == nil {
+		t.Error("AWSCluster CRD was nil.")
+	}
+	if crd.Name == "" {
+		t.Error("AWSCluster CRD name was empty.")
+	}
+}
+
+func Test_GenerateCertConfigYAML(t *testing.T) {
+	testCases := []struct {
+		category string
+		name     string
+		resource runtime.Object
+	}{
+		{
+			category: "crd",
+			name:     fmt.Sprintf("%s_certconfig.yaml", group),
+			resource: NewCertConfigCRD(),
+		},
+		{
+			category: "cr",
+			name:     fmt.Sprintf("%s_%s_certconfig.yaml", group, version),
+			resource: newCertConfigExampleCR(),
+		},
+	}
+
+	docs := filepath.Join(root, "..", "..", "..", "..", "docs")
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: generates %s successfully", i, tc.name), func(t *testing.T) {
+			rendered, err := yaml.Marshal(tc.resource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			directory := filepath.Join(docs, tc.category)
+			path := filepath.Join(directory, tc.name)
+
+			// We don't want a status in the docs YAML for the CR and CRD so that they work with `kubectl create -f <file>.yaml`.
+			// This just strips off the top level `status:` and everything following.
+			statusRegex := regexp.MustCompile(`(?ms)^status:.*$`)
+			rendered = statusRegex.ReplaceAll(rendered, []byte(""))
+
+			if *update {
+				err := ioutil.WriteFile(path, rendered, 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			goldenFile, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(rendered, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(rendered)))
+			}
+		})
+	}
+}
+
+func newCertConfigExampleCR() *CertConfig {
+	cr := NewCertConfigCR()
+
+	cr.Name = "c68pn-prometheus"
+	cr.Spec = CertConfigSpec{
+		Cert: CertConfigSpecCert{
+			AllowBareDomains:    false,
+			AltNames:            []string{},
+			ClusterComponent:    "prometheus",
+			ClusterID:           "c68pn",
+			CommonName:          "api.c68pn.k8s.gollum.westeurope.azure.gigantic.io",
+			DisableRegeneration: false,
+			IPSANs:              []string{},
+			Organizations:       []string{},
+			TTL:                 "4320h",
+		},
+		VersionBundle: CertConfigSpecVersionBundle{
+			Version: "0.1.0",
+		},
+	}
+
+	return cr
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8804

This prepares the CertConfig CRD to add OpenAPIv3 schema and property descriptions. It also provides an example CR which can be displayed in the CRD docs.

The example details are taken from a real world CR in an Azure installation.