### PR TITLE
Add revision to chart CR status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Helm revision number to chart CR status.
+
 ## [0.2.2] - 2020-04-07
 
 ### Added

--- a/pkg/apis/application/v1alpha1/chart_types.go
+++ b/pkg/apis/application/v1alpha1/chart_types.go
@@ -215,6 +215,8 @@ type ChartStatus struct {
 type ChartStatusRelease struct {
 	// LastDeployed is the time when the deployed chart was last deployed.
 	LastDeployed DeepCopyTime `json:"lastDeployed" yaml:"lastDeployed"`
+	// Revision is the revision number for this deployed chart.
+	Revision int `json:"revision" yaml:"revision"`
 	// Status is the status of the deployed chart,
 	// e.g. DEPLOYED.
 	Status string `json:"status" yaml:"status"`


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9900

We've had problems with the chart CR status not being set correctly. This makes trouble shooting difficult and can cause alerts.

This adds the Helm revision number to the status. This is useful info and will ensure we always update the status when it changes.

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
