### PR TITLE
Fix StorageConfig CRD loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Load StorageConfig from VFS as expected.
+
 ## [0.3.5] - 2020-05-06
 
 ### Added

--- a/pkg/apis/core/v1alpha1/storage_types.go
+++ b/pkg/apis/core/v1alpha1/storage_types.go
@@ -3,29 +3,17 @@ package v1alpha1
 import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/apiextensions/pkg/crd"
+)
+
+const (
+	kindStorageConfig = "StorageConfig"
 )
 
 // NewStorageConfigCRD returns a new custom resource definition for StorageConfig.
 func NewStorageConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
-	return &apiextensionsv1beta1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: apiextensionsv1beta1.SchemeGroupVersion.String(),
-			Kind:       "CustomResourceDefinition",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "storageconfigs.core.giantswarm.io",
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "core.giantswarm.io",
-			Scope:   "Namespaced",
-			Version: "v1alpha1",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Kind:     "StorageConfig",
-				Plural:   "storageconfigs",
-				Singular: "storageconfig",
-			},
-		},
-	}
+	return crd.LoadV1Beta1(group, kindStorageConfig)
 }
 
 // +genclient


### PR DESCRIPTION
I noticed in https://github.com/giantswarm/apiextensions/pull/441 that I didn't load the StorageConfig CRD from the pkger filesystem YAMLs. To keep the other PR small, I'm fixing this here.

## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [x] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
