### PR TITLE
Add changelog for empty 0.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] 2020-05-08
+
+- No changes.
+
 ## [0.3.7] 2020-05-08
 
 ### Added
@@ -180,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release.
 
 
-[Unreleased]: https://github.com/giantswarm/apiextensions/compare/v0.3.7...HEAD
+[Unreleased]: https://github.com/giantswarm/apiextensions/compare/v0.3.8...HEAD
+[0.3.8]: https://github.com/giantswarm/apiextensions/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/giantswarm/apiextensions/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/giantswarm/apiextensions/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/giantswarm/apiextensions/compare/v0.3.4...v0.3.5


### PR DESCRIPTION
## Checklist

There was an accidental move of the `0.3.7` tag in `apiextensions`. This move of the tag completely breaks go modules. Therefore this empty release is necessary.

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [x] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
