### PR TITLE
Add generation of CRD storageversion if multiple versions are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add code generation directive to set CRD storage version when multiple
-  versions for given type are present.
+- Add code generation directive (`+kubebuilder:storageversion`) to set CRD
+  storage version when multiple versions for given type are present.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add code generation directive to set CRD storage version when multiple
+  versions for given type are present.
+
+
 ## [0.3.8] 2020-05-08
 
 - No changes.

--- a/pkg/apis/application/v1alpha1/app_catalog_types.go
+++ b/pkg/apis/application/v1alpha1/app_catalog_types.go
@@ -99,7 +99,6 @@ type AppCatalogSpecStorage struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AppCatalogList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/application/v1alpha1/app_catalog_types.go
+++ b/pkg/apis/application/v1alpha1/app_catalog_types.go
@@ -39,6 +39,7 @@ func NewAppCatalogCR() *AppCatalog {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AppCatalog struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -98,6 +99,7 @@ type AppCatalogSpecStorage struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AppCatalogList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -176,7 +176,6 @@ type AppStatusRelease struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AppList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/application/v1alpha1/app_types.go
+++ b/pkg/apis/application/v1alpha1/app_types.go
@@ -37,6 +37,7 @@ func NewAppCR() *App {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type App struct {
@@ -175,6 +176,7 @@ type AppStatusRelease struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AppList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/application/v1alpha1/chart_types.go
+++ b/pkg/apis/application/v1alpha1/chart_types.go
@@ -127,7 +127,6 @@ type ChartStatusRelease struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type ChartList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/application/v1alpha1/chart_types.go
+++ b/pkg/apis/application/v1alpha1/chart_types.go
@@ -37,6 +37,7 @@ func NewChartCR() *Chart {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type Chart struct {
@@ -126,6 +127,7 @@ type ChartStatusRelease struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type ChartList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/backup/v1alpha1/etcd_backup_types.go
+++ b/pkg/apis/backup/v1alpha1/etcd_backup_types.go
@@ -74,7 +74,6 @@ type ETCDInstanceBackupStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 type ETCDBackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/backup/v1alpha1/etcd_backup_types.go
+++ b/pkg/apis/backup/v1alpha1/etcd_backup_types.go
@@ -18,6 +18,7 @@ func NewETCDBackupCRD() *v1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type ETCDBackup struct {
@@ -73,6 +74,7 @@ type ETCDInstanceBackupStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 type ETCDBackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/core/v1alpha1/aws_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/aws_cluster_types.go
@@ -18,6 +18,7 @@ func NewAWSClusterConfigCRD() *v1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AWSClusterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -63,6 +64,7 @@ type AWSClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AWSClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/aws_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/aws_cluster_types.go
@@ -64,7 +64,6 @@ type AWSClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AWSClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/azure_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/azure_cluster_types.go
@@ -18,6 +18,7 @@ func NewAzureClusterConfigCRD() *v1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AzureClusterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -66,6 +67,7 @@ type AzureClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AzureClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/azure_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/azure_cluster_types.go
@@ -67,7 +67,6 @@ type AzureClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AzureClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/cert_types.go
+++ b/pkg/apis/core/v1alpha1/cert_types.go
@@ -71,7 +71,6 @@ type CertConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type CertConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/cert_types.go
+++ b/pkg/apis/core/v1alpha1/cert_types.go
@@ -41,6 +41,7 @@ func NewCertConfigCR() *CertConfig {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type CertConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -70,6 +71,7 @@ type CertConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type CertConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -95,7 +95,6 @@ type ChartConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type ChartConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/chart_types.go
+++ b/pkg/apis/core/v1alpha1/chart_types.go
@@ -17,6 +17,7 @@ func NewChartConfigCRD() *v1beta1.CustomResourceDefinition {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type ChartConfig struct {
@@ -94,6 +95,7 @@ type ChartConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type ChartConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/drainer_types.go
+++ b/pkg/apis/core/v1alpha1/drainer_types.go
@@ -102,7 +102,6 @@ type DrainerConfigStatusCondition struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type DrainerConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/drainer_types.go
+++ b/pkg/apis/core/v1alpha1/drainer_types.go
@@ -36,6 +36,7 @@ func NewDrainerTypeMeta() metav1.TypeMeta {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type DrainerConfig struct {
@@ -101,6 +102,7 @@ type DrainerConfigStatusCondition struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type DrainerConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/flannel_types.go
+++ b/pkg/apis/core/v1alpha1/flannel_types.go
@@ -18,6 +18,7 @@ func NewFlannelConfigCRD() *v1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type FlannelConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -87,6 +88,7 @@ type FlannelConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type FlannelConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/flannel_types.go
+++ b/pkg/apis/core/v1alpha1/flannel_types.go
@@ -88,7 +88,6 @@ type FlannelConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type FlannelConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/ignition_types.go
+++ b/pkg/apis/core/v1alpha1/ignition_types.go
@@ -283,7 +283,6 @@ type IgnitionStatusSecret struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type IgnitionList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/ignition_types.go
+++ b/pkg/apis/core/v1alpha1/ignition_types.go
@@ -17,6 +17,7 @@ func NewIgnitionTypeMeta() metav1.TypeMeta {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // Ignition is a Kubernetes resource (CR) which is based on the Ignition CRD defined above.
@@ -282,6 +283,7 @@ type IgnitionStatusSecret struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type IgnitionList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/kvm_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/kvm_cluster_types.go
@@ -61,7 +61,6 @@ type KVMClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type KVMClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/kvm_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/kvm_cluster_types.go
@@ -18,6 +18,7 @@ func NewKVMClusterConfigCRD() *v1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type KVMClusterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -60,6 +61,7 @@ type KVMClusterConfigSpecVersionBundle struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type KVMClusterConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/storage_types.go
+++ b/pkg/apis/core/v1alpha1/storage_types.go
@@ -19,6 +19,7 @@ func NewStorageConfigCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type StorageConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -35,6 +36,7 @@ type StorageConfigSpecStorage struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type StorageConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/core/v1alpha1/storage_types.go
+++ b/pkg/apis/core/v1alpha1/storage_types.go
@@ -36,7 +36,6 @@ type StorageConfigSpecStorage struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type StorageConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/example/v1alpha1/memcached_types.go
+++ b/pkg/apis/example/v1alpha1/memcached_types.go
@@ -18,6 +18,7 @@ func NewMemcachedConfigCRD() *v1beta1.CustomResourceDefinition {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type MemcachedConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -35,6 +36,7 @@ type MemcachedConfigSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type MemcachedConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/example/v1alpha1/memcached_types.go
+++ b/pkg/apis/example/v1alpha1/memcached_types.go
@@ -36,7 +36,6 @@ type MemcachedConfigSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type MemcachedConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -165,7 +165,6 @@ type AWSClusterStatusProviderNetwork struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 // AWSClusterList is the type returned when listing AWSCLuster resources.
 type AWSClusterList struct {

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -38,6 +38,7 @@ func NewAWSClusterCR() *AWSCluster {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // AWSCluster is the infrastructure provider referenced in upstream CAPI Cluster
@@ -164,6 +165,7 @@ type AWSClusterStatusProviderNetwork struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 // AWSClusterList is the type returned when listing AWSCLuster resources.
 type AWSClusterList struct {

--- a/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -64,7 +64,6 @@ type AWSControlPlaneSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AWSControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -41,6 +41,7 @@ func NewAWSControlPlaneCR() *AWSControlPlane {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 // AWSControlPlane is the infrastructure provider referenced in ControlPlane
 // CRs. Represents the master nodes (also called Control Plane) of a tenant
@@ -63,6 +64,7 @@ type AWSControlPlaneSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AWSControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/aws_machine_deployment_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_machine_deployment_types.go
@@ -143,7 +143,6 @@ type AWSMachineDeploymentStatusProviderWorker struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AWSMachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/aws_machine_deployment_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_machine_deployment_types.go
@@ -36,6 +36,7 @@ func NewAWSMachineDeploymentCR() *AWSMachineDeployment {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // AWSMachineDeployment is the infrastructure provider referenced in Kubernetes Cluster API MachineDeployment resources.
@@ -142,6 +143,7 @@ type AWSMachineDeploymentStatusProviderWorker struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AWSMachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
@@ -75,7 +75,6 @@ type G8sControlPlaneStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type G8sControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
@@ -38,6 +38,7 @@ func NewG8sControlPlaneCR() *G8sControlPlane {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 // The G8sControlPlane resource defines the Control Plane nodes (Kubernetes master nodes) of
@@ -74,6 +75,7 @@ type G8sControlPlaneStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type G8sControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -198,7 +198,6 @@ type AWSConfigStatusAWSAvailabilityZoneSubnetPublic struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AWSConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -41,6 +41,7 @@ func NewAWSConfigCR() *AWSConfig {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type AWSConfig struct {
@@ -197,6 +198,7 @@ type AWSConfigStatusAWSAvailabilityZoneSubnetPublic struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AWSConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -17,6 +17,7 @@ func NewAzureConfigCRD() *v1.CustomResourceDefinition {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type AzureConfig struct {
@@ -121,6 +122,7 @@ type AzureConfigStatusProviderIngressLoadBalancer struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type AzureConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/pkg/apis/provider/v1alpha1/azure_types.go
@@ -122,7 +122,6 @@ type AzureConfigStatusProviderIngressLoadBalancer struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type AzureConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/kvm_types.go
+++ b/pkg/apis/provider/v1alpha1/kvm_types.go
@@ -17,6 +17,7 @@ func NewKVMConfigCRD() *v1beta1.CustomResourceDefinition {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type KVMConfig struct {
@@ -108,6 +109,7 @@ type KVMConfigStatusKVM struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type KVMConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/provider/v1alpha1/kvm_types.go
+++ b/pkg/apis/provider/v1alpha1/kvm_types.go
@@ -109,7 +109,6 @@ type KVMConfigStatusKVM struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type KVMConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/release/v1alpha1/release_cycle_types.go
+++ b/pkg/apis/release/v1alpha1/release_cycle_types.go
@@ -61,7 +61,6 @@ type ReleaseCycleStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type ReleaseCycleList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/release/v1alpha1/release_cycle_types.go
+++ b/pkg/apis/release/v1alpha1/release_cycle_types.go
@@ -36,6 +36,7 @@ func NewReleaseCycleTypeMeta() metav1.TypeMeta {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
 type ReleaseCycle struct {
@@ -60,6 +61,7 @@ type ReleaseCycleStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type ReleaseCycleList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/release/v1alpha1/release_types.go
+++ b/pkg/apis/release/v1alpha1/release_types.go
@@ -99,7 +99,6 @@ type ReleaseSpecApp struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 type ReleaseList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/release/v1alpha1/release_types.go
+++ b/pkg/apis/release/v1alpha1/release_types.go
@@ -54,6 +54,7 @@ func NewReleaseCR() *Release {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 // Release is a Kubernetes resource (CR) which is based on the Release CRD defined above.
 //
@@ -98,6 +99,7 @@ type ReleaseSpecApp struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 type ReleaseList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/tooling/v1alpha1/azure_tool_types.go
+++ b/pkg/apis/tooling/v1alpha1/azure_tool_types.go
@@ -43,7 +43,6 @@ type AzureToolWorkspace struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:storageversion
 
 // AzureToolList is the type returned when listing AzureToolList resources.
 type AzureToolList struct {

--- a/pkg/apis/tooling/v1alpha1/azure_tool_types.go
+++ b/pkg/apis/tooling/v1alpha1/azure_tool_types.go
@@ -17,6 +17,7 @@ func NewAzureToolCRD() *v1.CustomResourceDefinition {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 type AzureTool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -42,6 +43,7 @@ type AzureToolWorkspace struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 
 // AzureToolList is the type returned when listing AzureToolList resources.
 type AzureToolList struct {


### PR DESCRIPTION
// +kubebuilder:storageversion marks the given CRD version as the one that
should be used for storage (i.e. persisting in etcd). When there are no other
versions of given CRD, it doesn't generate anything. When new version is added,
one must decided case-by-case which version should be stored in etcd.

This is preparation to introduce `infrastructure/v1alpha3` for Azure
Cluster API types and Node Pools.

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
