### PR TITLE
Catch and fix errors while parsing CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Serialization of KVM fields `MemorySizeGB`, `StorageSizeGB`, and `Disk` broken during migration to `kubebuilder`.
 - Code generation from within `$GOPATH`.
+- Loading of `AWSMachineDeployment` CRD.
 
 
 

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 
@@ -36,7 +35,7 @@ var (
 	}
 )
 
-type objectHandler func(unstructured.Unstructured)
+type objectHandler func(data []byte) error
 
 func iterateResources(groupVersionKind schema.GroupVersionKind, handle objectHandler) error {
 	crdDirectory := fmt.Sprintf("/config/crd/%s", groupVersionKind.Version)
@@ -78,7 +77,9 @@ func iterateResources(groupVersionKind schema.GroupVersionKind, handle objectHan
 			continue
 		}
 
-		handle(object)
+		if err := handle(contents); err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	return nil
@@ -93,14 +94,14 @@ func ListV1Beta1() ([]v1beta1.CustomResourceDefinition, error) {
 		return cacheV1Beta1, nil
 	}
 
-	handler := func(unstructured unstructured.Unstructured) {
+	handler := func(data []byte) error {
 		var crd v1beta1.CustomResourceDefinition
-		err := runtime.DefaultUnstructuredConverter.
-			FromUnstructured(unstructured.UnstructuredContent(), &crd)
+		err := yaml.UnmarshalStrict(data, &crd)
 		if err != nil {
-			return
+			return microerror.Mask(err)
 		}
 		cacheV1Beta1 = append(cacheV1Beta1, crd)
+		return nil
 	}
 
 	err := iterateResources(v1beta1GroupVersionKind, handler)
@@ -117,14 +118,14 @@ func ListV1() ([]v1.CustomResourceDefinition, error) {
 		return cache, nil
 	}
 
-	handler := func(unstructured unstructured.Unstructured) {
+	handler := func(data []byte) error {
 		var crd v1.CustomResourceDefinition
-		err := runtime.DefaultUnstructuredConverter.
-			FromUnstructured(unstructured.UnstructuredContent(), &crd)
+		err := yaml.UnmarshalStrict(data, &crd)
 		if err != nil {
-			return
+			return microerror.Mask(err)
 		}
 		cache = append(cache, crd)
+		return nil
 	}
 
 	err := iterateResources(v1GroupVersionKind, handler)


### PR DESCRIPTION
I just found out that errors were being missed (namely `cannot convert int64 to float64`) while converting `AWSMachineDeployment` CRD from `unstructured.Unstructured` to `CustomResourceDefinition`. This PR adds more error checking and unmarshals CRDs from the YAML string rather than attempting to convert from `Unstructured`.