### PR TITLE
Add util functions for working with multiple CRD versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ExtractV1CRDVersions()` and `WithStorageVersion()` functions to work with
+  multi-versioned CRDs easier on different platforms.
+
 ## [0.4.3] 2020-05-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ExtractV1CRDVersions()` and `WithStorageVersion()` functions to work with
+- Add `crd.ExtractV1CRDVersions()` and `crd.WithStorageVersion()` functions to work with
   multi-versioned CRDs easier on different platforms.
 
 ## [0.4.3] 2020-05-25

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -179,14 +179,20 @@ func LoadV1(group, kind string) *v1.CustomResourceDefinition {
 func ExtractV1CRDVersions(crd *v1.CustomResourceDefinition, versions ...string) *v1.CustomResourceDefinition {
 	crd = crd.DeepCopy()
 
-VERSION_LOOP:
+	inSpecifiedVersions := func(v string) bool {
+		for _, name := range versions {
+			if v == name {
+				return true
+			}
+		}
+		return false
+	}
+
 	for i := 0; i < len(crd.Spec.Versions); i++ {
 		v := crd.Spec.Versions[i]
-		for _, name := range versions {
-			if v.Name == name {
-				// Keep current version and proceed to next.
-				continue VERSION_LOOP
-			}
+
+		if inSpecifiedVersions(v.Name) {
+			continue
 		}
 
 		// Remove current element since its version was not specified in versions.

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -2,6 +2,9 @@ package crd
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func Test_List(t *testing.T) {
@@ -81,6 +84,275 @@ func Test_Load(t *testing.T) {
 			}
 			if crd == nil {
 				t.Errorf("nil crd")
+			}
+		})
+	}
+}
+
+func Test_ExtractV1CRDVersions(t *testing.T) {
+	testCases := []struct {
+		name        string
+		crd         *v1.CustomResourceDefinition
+		versions    []string
+		expectedCRD *v1.CustomResourceDefinition
+	}{
+		{
+			name: "case 0: simple case, drop one of two",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha2",
+						},
+					},
+				},
+			},
+			versions: []string{"v1alpha1"},
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 1: drop one of three",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha2",
+						},
+						{
+							Name: "v1alpha3",
+						},
+					},
+				},
+			},
+			versions: []string{"v1alpha1", "v1alpha3"},
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha3",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 2: return all three",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha2",
+						},
+						{
+							Name: "v1alpha3",
+						},
+					},
+				},
+			},
+			versions: []string{"v1alpha1", "v1alpha2", "v1alpha3"},
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha2",
+						},
+						{
+							Name: "v1alpha3",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 3: drop all three",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name: "v1alpha1",
+						},
+						{
+							Name: "v1alpha2",
+						},
+						{
+							Name: "v1alpha3",
+						},
+					},
+				},
+			},
+			versions: []string{},
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			crd := ExtractV1CRDVersions(tc.crd, tc.versions...)
+
+			if !cmp.Equal(crd, tc.expectedCRD) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expectedCRD, crd))
+			}
+		})
+	}
+}
+
+func Test_WithStorageVersion(t *testing.T) {
+	nilPanicMatcher := func(ret interface{}) bool {
+		return ret == nil
+	}
+	notFoundPanicMatcher := func(ret interface{}) bool {
+		err, ok := ret.(error)
+		return ok && IsNotFound(err)
+	}
+
+	testCases := []struct {
+		name         string
+		crd          *v1.CustomResourceDefinition
+		version      string
+		expectedCRD  *v1.CustomResourceDefinition
+		panicMatcher func(ret interface{}) bool
+	}{
+		{
+			name: "case 0: switch storage version",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: true,
+						},
+					},
+				},
+			},
+			version: "v1alpha1",
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: true,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: false,
+						},
+					},
+				},
+			},
+			panicMatcher: nilPanicMatcher,
+		},
+		{
+			name: "case 1: keep the set one",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: true,
+						},
+					},
+				},
+			},
+			version: "v1alpha2",
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: true,
+						},
+					},
+				},
+			},
+			panicMatcher: nilPanicMatcher,
+		},
+		{
+			name: "case 2: panic not found",
+			crd: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: true,
+						},
+					},
+				},
+			},
+			version: "v1alpha3",
+			expectedCRD: &v1.CustomResourceDefinition{
+				Spec: v1.CustomResourceDefinitionSpec{
+					Versions: []v1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1alpha2",
+							Storage: false,
+						},
+					},
+				},
+			},
+			panicMatcher: notFoundPanicMatcher,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				err := recover()
+				if !tc.panicMatcher(err) {
+					t.Errorf("unexpected panic: %#v", err)
+				}
+			}()
+
+			crd := WithStorageVersion(tc.crd, tc.version)
+
+			if !cmp.Equal(crd, tc.expectedCRD) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expectedCRD, crd))
 			}
 		})
 	}


### PR DESCRIPTION
Introduce two functions that can be used to work with different CRD versions on
different platforms.

Main objective here is to provide functionality for `opsctl` so that AWS can
use one version of Cluster API CRDs while Azure uses different one. This way
one can specify which versions to get and which one to set as storage version.

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
