### PR TITLE
add label and annotation packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `pkg/label` and `pkg/annotation` as strategic single source of truth.
+
+
+
 ## [0.4.13] - 2020-07-13
 
 - `AWSMachineDeployment`: Made `OnDemandBaseCapacity` and `OnDemandPercentageAboveBaseCapacity` optional attributes, removed default value for `OnDemandPercentageAboveBaseCapacity`.

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -1,0 +1,6 @@
+package annotation
+
+// Docs is the docs annotation put into all CRs to link to its CR specific
+// documentation. This aims to help understanding all the moving parts within
+// the system and how they relate to each other.
+const Docs = "giantswarm.io/docs"

--- a/pkg/label/id.go
+++ b/pkg/label/id.go
@@ -1,0 +1,17 @@
+package label
+
+// Cluster is the ID label put into all CRs to identify which Tenant Cluster the
+// given CR is related to.
+const Cluster = "giantswarm.io/cluster"
+
+// ControlPlane is the ID label put into all Control Plane CRs to identify which
+// Master Nodes the given CR groups together.
+const ControlPlane = "giantswarm.io/control-plane"
+
+// MachineDeployment is the ID label put into all Machine Deployment CRs to
+// identify which Worker Nodes the given CR groups together.
+const MachineDeployment = "giantswarm.io/machine-deployment"
+
+// Organization is the ID label put into all CRs to identify which Organization
+// the given CR is related to.
+const Organization = "giantswarm.io/organization"

--- a/pkg/label/version.go
+++ b/pkg/label/version.go
@@ -1,0 +1,19 @@
+package label
+
+// AWSOperatorVersion is the version label put into AWS specific CRs to define
+// which aws-operator version should reconcile the given CR. Versions are
+// defined as semver version without the "v" prefix, e.g. 8.7.0, which means
+// that there is an aws-operator release v8.7.0.
+const AWSOperatorVersion = "aws-operator.giantswarm.io/version"
+
+// ClusterOperatorVersion is the version label put into provider independent CRs
+// to define which cluster-operator version should reconcile the given CR.
+// Versions are defined as semver version without the "v" prefix, e.g. 2.3.0,
+// which means that there is a cluster-operator release v2.3.0.
+const ClusterOperatorVersion = "cluster-operator.giantswarm.io/version"
+
+// ReleaseVersion is the version label put into all CRs to define which Giant
+// Swarm release the given CR is related to. Versions are defined as semver
+// version without the "v" prefix, e.g. 11.4.0, which means that there is a
+// Giant Swarm release v11.4.0.
+const ReleaseVersion = "release.giantswarm.io/version"


### PR DESCRIPTION
## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).



## Context

Right now we duplicate labels and annotations everywhere in our go code. Talking with @marians we thought it would be beneficial if we could generate documentation for labels and annotations used in our CRs. Therefore we would like to bootstrap a location for most common labels and annotations. This is the first iteration. Further we would like to work on our docs generator to incorporate the godoc all the good engineers provide here. Nothing written in stone. Let's talk if there is anything. 