### PR TITLE
Add azure nodepool labels and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `AzureOperatorVersion` to `pkg/label`.
+- Add`MachinePool` to `pkg/label`
+- Add `MachinePoolName` to `pkg/annotation`
 - Add `ReleaseNotesURL` to `pkg/annotation`.
 - Add descriptions to `App`, `AppCatalog` and `Chart` CRDs.
 - Add deprecation notice to `ChartConfig` CRD.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `AzureOperatorVersion` to `pkg/label`.
-- Add`MachinePool` to `pkg/label`
+- Add `MachinePool` to `pkg/label`
 - Add `MachinePoolName` to `pkg/annotation`
 - Add `ReleaseNotesURL` to `pkg/annotation`.
 - Add descriptions to `App`, `AppCatalog` and `Chart` CRDs.

--- a/pkg/annotation/nodepool.go
+++ b/pkg/annotation/nodepool.go
@@ -1,0 +1,7 @@
+package annotation
+
+const (
+	// MachinePoolName is the annotation where customer-set human-friendly node
+	// pool name is stored.
+	MachinePoolName = "machine-pool.giantswarm.io/name"
+)

--- a/pkg/annotation/nodepool.go
+++ b/pkg/annotation/nodepool.go
@@ -3,9 +3,3 @@ package annotation
 // MachinePoolName is the node pool annotation where human-friendly node pool
 // name set by the customer is stored.
 const MachinePoolName = "machine-pool.giantswarm.io/name"
-
-// MachinePoolSubnet is the node pool annotation which contains the name of the
-// subnet where the tenant cluster node pool is deployed. This name should be
-// equivalent to the tenant cluster node pool ID. E.g.
-// machine-pool.giantswarm.io/subnet=de19f-h94vd.
-const MachinePoolSubnet = "machine-pool.giantswarm.io/subnet"

--- a/pkg/annotation/nodepool.go
+++ b/pkg/annotation/nodepool.go
@@ -1,7 +1,11 @@
 package annotation
 
-const (
-	// MachinePoolName is the annotation where customer-set human-friendly node
-	// pool name is stored.
-	MachinePoolName = "machine-pool.giantswarm.io/name"
-)
+// MachinePoolName is the node pool annotation where human-friendly node pool
+// name set by the customer is stored.
+const MachinePoolName = "machine-pool.giantswarm.io/name"
+
+// MachinePoolSubnet is the node pool annotation which contains the name of the
+// subnet where the tenant cluster node pool is deployed. This name should be
+// equivalent to the tenant cluster node pool ID. E.g.
+// machine-pool.giantswarm.io/subnet=de19f-h94vd.
+const MachinePoolSubnet = "machine-pool.giantswarm.io/subnet"

--- a/pkg/label/id.go
+++ b/pkg/label/id.go
@@ -12,6 +12,11 @@ const ControlPlane = "giantswarm.io/control-plane"
 // identify which Worker Nodes the given CR groups together.
 const MachineDeployment = "giantswarm.io/machine-deployment"
 
+// MachinePool is the ID label put into all MachinePool and AzureMachinePool CRs
+// and it contains tenant cluster node pool ID (i.e. the machine pool ID). E.g.
+// giantswarm.io/machine-pool=de19f-h94vd.
+const MachinePool = "giantswarm.io/machine-pool"
+
 // Organization is the ID label put into all CRs to identify which Organization
 // the given CR is related to.
 const Organization = "giantswarm.io/organization"

--- a/pkg/label/version.go
+++ b/pkg/label/version.go
@@ -8,8 +8,8 @@ const AWSOperatorVersion = "aws-operator.giantswarm.io/version"
 
 // AzureOperatorVersion is the version label put into Azure specific CRs to define
 // which azure-operator version should reconcile the given CR. Versions are
-// defined as semver version without the "v" prefix, e.g. 8.7.0, which means
-// that there is an azure-operator release v8.7.0.
+// defined as semver version without the "v" prefix, e.g. 4.1.0, which means
+// that there is an azure-operator release v4.1.0.
 const AzureOperatorVersion = "azure-operator.giantswarm.io/version"
 
 // ClusterOperatorVersion is the version label put into provider independent CRs


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/160

- Moved label `MachinePool` from API repo to `pkg/label`.
- Added annotation `MachinePoolName` to `pkg/annotation`.