### PR TITLE
Add cluster description annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ClusterDescription` to `pkg/annotation`
+
 ## [0.4.18] - 2020-07-27
 
 - Add `EndOfLifeDate` to `Release` CRD.

--- a/pkg/annotation/cluster.go
+++ b/pkg/annotation/cluster.go
@@ -1,0 +1,5 @@
+package annotation
+
+// ClusterDescription is the cluster annotation used for storing
+// a customer's cluster description.
+const ClusterDescription = "cluster.giantswarm.io/description"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12363

This adds a cluster description annotation, which we'll use to specify an user friendly cluster description for Azure v5 clusters.
