### PR TITLE
Added new constants for cluster autoscaling annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `InUse` to the `ReleaseStatus`.
 - Add `KVMOperatorVersion` label.
+- Added constants for node pools autoscaling annotation names.
 
 ## [2.1.0] - 2020-08-17
 

--- a/pkg/annotation/clusterautoscaler.go
+++ b/pkg/annotation/clusterautoscaler.go
@@ -1,0 +1,9 @@
+package annotation
+
+// AnnotationNodePoolMinSize is the cluster annotation used for storing
+// the minimum size of a node pool.
+const NodePoolMinSize = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
+
+// AnnotationNodePoolMaxSize is the cluster annotation used for storing
+// the maximum size of a node pool.
+const NodePoolMaxSize = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13200

This PR adds 2 constants that hold the names of annotations needed by cluster autoscaler.