### PR TITLE
add-node-auto-repair-annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add annotation to enable node automatic repair feature.
+
 ## [3.3.0] - 2020-10-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add annotation to enable node automatic repair feature.
+- Add annotation to enable node auto-repair feature.
 
 ## [3.3.0] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add annotation to enable node auto-repair feature.
+- Add annotation to enable feature to terminate unhealthy nodes on a cluster.
 
 ## [3.3.0] - 2020-10-23
 

--- a/pkg/annotation/nodeautomation.go
+++ b/pkg/annotation/nodeautomation.go
@@ -1,0 +1,4 @@
+package annotation
+
+// Annotation used to enable feature to terminate bad nodes.
+const NodeAutoRepair = "node-automation.giantswarm.io/repair"

--- a/pkg/annotation/nodeautomation.go
+++ b/pkg/annotation/nodeautomation.go
@@ -1,4 +1,4 @@
 package annotation
 
 // Annotation used to enable feature to terminate bad nodes.
-const NodeAutoRepair = "node-automation.giantswarm.io/repair"
+const NodeAutoRepair = "node.giantswarm.io/auto-repair"

--- a/pkg/annotation/nodeautomation.go
+++ b/pkg/annotation/nodeautomation.go
@@ -1,4 +1,4 @@
 package annotation
 
-// Annotation used to enable feature to terminate bad nodes.
-const NodeAutoRepair = "node.giantswarm.io/auto-repair"
+// Annotation used to enable feature to terminate unhealthy nodes on a cluster CR.
+const NodeTerminateUnhealthy = "node.giantswarm.io/terminate-unhealthy"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/10357

the annotation will be used on cluster CR to enable the feature

but naming is hard so if anyone has some cool ideas for cool names feel free to share, I am open to suggestions :)
 (the feature is about terminating bad nodes, on GKE they named it 'node auto-repair feature')


## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
