### PR TITLE
Add catalog and k8s labels and notes annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add catalog and kubernetes labels and notes annotation.
+
 ## [3.4.1] - 2020-10-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add catalog and kubernetes labels and notes annotation.
+
 ## [3.5.0] - 2020-11-03
 
 ### Added
 
 - Add 'AWSMetadataV2' annotation to configure the metadata endpoint.
 - Add 'AWSSubnetSize' annotation to configure the subnet size of Control Plane and Machinedeployments.
-- Add catalog and kubernetes labels and notes annotation.
 
 ## [3.4.1] - 2020-10-29
 

--- a/pkg/annotation/general.go
+++ b/pkg/annotation/general.go
@@ -8,7 +8,7 @@ package annotation
 const Docs = "giantswarm.io/docs"
 
 // Notes is for informational messages for resources managed by operators. Such
-// as whether they resources should be edited.
+// as whether the resource may or may not be edited.
 const Notes = "giantswarm.io/notes"
 
 // ReleaseNotesURL defines where to find release notes about the CR at hand.

--- a/pkg/annotation/general.go
+++ b/pkg/annotation/general.go
@@ -7,6 +7,10 @@ package annotation
 // the system and how they relate to each other.
 const Docs = "giantswarm.io/docs"
 
+// Notes is for informational messages for resources managed by operators. Such
+// as whether they resources should be edited.
+const Notes = "giantswarm.io/notes"
+
 // ReleaseNotesURL defines where to find release notes about the CR at hand.
 // The value is expected to be a URI, e. g.
 // "https://github.com/giantswarm/releases/tree/master/aws/v11.5.0".

--- a/pkg/label/catalog.go
+++ b/pkg/label/catalog.go
@@ -1,0 +1,13 @@
+package label
+
+// CatalogName label is used to identify resources belonging to a Giant Swarm
+// app catalog.
+const CatalogName = "application.giantswarm.io/catalog"
+
+// CatalogType label is used to identify the type of Giant Swarm app catalog
+// e.g. stable or test.
+const CatalogType = "application.giantswarm.io/catalog-type"
+
+// CatalogVisibility label is used to determine how Giant Swarm app catalogs
+// are displayed in the UX. e.g. public or internal.
+const CatalogVisibility = "application.giantswarm.io/catalog-visibility"

--- a/pkg/label/kubernetes.go
+++ b/pkg/label/kubernetes.go
@@ -1,7 +1,7 @@
 package label
 
 // AppKubernetesInstance is a unique name identifying an instance of an app.
-const AppKubernetesInstance = "app.kubernetes.io/name"
+const AppKubernetesInstance = "app.kubernetes.io/instance"
 
 // AppKubernetesName label is used to identify Kubernetes resources.
 const AppKubernetesName = "app.kubernetes.io/name"

--- a/pkg/label/kubernetes.go
+++ b/pkg/label/kubernetes.go
@@ -1,0 +1,11 @@
+package label
+
+// AppKubernetesInstance is a unique name identifying an instance of an app.
+const AppKubernetesInstance = "app.kubernetes.io/name"
+
+// AppKubernetesName label is used to identify Kubernetes resources.
+const AppKubernetesName = "app.kubernetes.io/name"
+
+// AppKubernetesVersion label is used to identify the version of Kubernetes
+// resources.
+const AppKubernetesVersion = "app.kubernetes.io/version"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11656

Moves metadata from app-operator so it can be reused in app-admission-controller.

## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
