### PR TITLE
Add release.giantswarm.io/last-deployed-version annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add catalog and kubernetes labels and notes annotation.
+- Add `release.giantswarm.io/last-deployed-version` `Cluster` CR annotation
 
 ## [3.5.0] - 2020-11-03
 

--- a/pkg/annotation/version.go
+++ b/pkg/annotation/version.go
@@ -1,0 +1,8 @@
+package annotation
+
+// LastDeployedReleaseVersion is the version annotation put into Cluster CR to
+// define which Giant Swarm release version was last successfully deployed
+// during cluster creation or upgrade. Versions are defined as semver version
+// without the "v" prefix, e.g. 14.1.0, which means that cluster was created
+// with or upgraded to Giant Swarm release v14.1.0.
+const LastDeployedReleaseVersion = "release.giantswarm.io/last-deployed-version"


### PR DESCRIPTION
Add `release.giantswarm.io/last-deployed-version` annotation that is put into Cluster CR to define which Giant Swarm release version was last successfully deployed during cluster creation or upgrade.

Having this annotation will make setting of `Cluster` `Creating` and `Upgrading` conditions update implementation more reliable and more straightforward.

## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [x] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
