### PR TITLE
Add legacy app label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `Restrictions` metadata to `AppCatalogEntry` CRD.
+- Add legacy `app` label.
 
 ## [3.7.0] - 2020-11-04
 

--- a/pkg/label/kubernetes.go
+++ b/pkg/label/kubernetes.go
@@ -1,5 +1,9 @@
 package label
 
+// App label is used to identify Kubernetes resources. It is considered
+// deprecated by upstream and is replaced by `app.kubernetes.io/name`.
+const App = "app"
+
 // AppKubernetesInstance is a unique name identifying an instance of an app.
 const AppKubernetesInstance = "app.kubernetes.io/instance"
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#11656

Needed for https://github.com/giantswarm/app-admission-controller/pull/23.

We want to default the `app.kubernetes.io/name` label but some app CRs have the legacy `app` label. e.g. those managed by cluster-operator.


## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
