### PR TITLE
Graduate Organization CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Graduate `Organization` CRD to v1.
+
 ### Added
 
 - Add `Restrictions` metadata to `AppCatalogEntry` CRD.

--- a/pkg/apis/security/v1alpha1/organization_types.go
+++ b/pkg/apis/security/v1alpha1/organization_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/crd"
@@ -11,8 +11,8 @@ const (
 	kindOrganization = "Organization"
 )
 
-func NewOrganizationCRD() *v1beta1.CustomResourceDefinition {
-	return crd.LoadV1Beta1(group, kindOrganization)
+func NewOrganizationCRD() *v1.CustomResourceDefinition {
+	return crd.LoadV1(group, kindOrganization)
 }
 
 // +genclient

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -56,6 +56,13 @@ func Test_Load(t *testing.T) {
 			panicMatcher:    nilPanicMatcher,
 		},
 		{
+			name:            "case 3: Organization CRD loads normally",
+			inputGroup:      "security.giantswarm.io",
+			inputKind:       "Organization",
+			inputCRDVersion: "v1",
+			panicMatcher:    nilPanicMatcher,
+		},
+		{
 			name:            "case 3: non-existent v1 CRD panics with notFoundError",
 			inputGroup:      "application.giantswarm.io",
 			inputKind:       "Bad",


### PR DESCRIPTION
I want to graduate the `Organization` CRD from `v1beta1` to `v1`. The weird thing is that the YAML file with the CRD definition in `config/crd/v1/security.giantswarm.io_organizations.yaml` was already defining it as `v1`. I don't understand how this can be possible if the go object was defined using `v1beta1`. Actually, running `make` doesn't update any files.

To finish the graduation, after merging this we need to release a new version of `apiextensions`, and use that new version from clients using the `Organization` CRD like `opsctl`, `organization-operator` or some Celestial components. Is there anything else to do to complete the graduation?

## Checklist

- [ ] Consider SIG UX feedback.
- [X] Update changelog in CHANGELOG.md.
- [X] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
