### PR TITLE
Add annotations for apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change (unused yet) `config.giantswarm.io/major-version` annotation to `config.giantswarm.io/version`.
 
+### Added
+
+- Add `app-operator.giantswarm.io/latest-configmap-version` annotation.
+- Add `app-operator.giantswarm.io/latest-secret-version` annotation.
+
 ## [3.10.0] - 2020-11-30
 
 ### Changed

--- a/pkg/annotation/app.go
+++ b/pkg/annotation/app.go
@@ -1,0 +1,9 @@
+package annotation
+
+// LatestConfigMapVersion is the highest resource version among the configmaps
+// app CRs depends on.
+const LatestConfigMapVersion = "app-operator.giantswarm.io/giantswarm.io/latest-configmap-version"
+
+// LatestSecretVersion is the highest resource version among the secret
+// app CRs depends on.
+const LatestSecretVersion = "app-operator.giantswarm.io/latest-secret-version"


### PR DESCRIPTION
`LatestConfigMapVersion`, `LatestSecretVersion` is needed by two operators at the moment. 
It makes sense to move these to apiextensions. 

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
