### PR TITLE
Set LastHeartbeatTime when creating Conditions for DrainerConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set a `LastHeartbeatTime` when creating new `Condition`s for `DrainerConfig`s.
+
 ## [3.15.0] - 2021-01-21
 
 ### Added

--- a/pkg/apis/core/v1alpha1/drainer_funcs.go
+++ b/pkg/apis/core/v1alpha1/drainer_funcs.go
@@ -14,6 +14,7 @@ func (s DrainerConfigStatus) HasTimeoutCondition() bool {
 
 func (s DrainerConfigStatus) NewDrainedCondition() DrainerConfigStatusCondition {
 	return DrainerConfigStatusCondition{
+		LastHeartbeatTime:  metav1.Now(),
 		LastTransitionTime: metav1.Now(),
 		Status:             DrainerConfigStatusStatusTrue,
 		Type:               DrainerConfigStatusTypeDrained,
@@ -22,6 +23,7 @@ func (s DrainerConfigStatus) NewDrainedCondition() DrainerConfigStatusCondition 
 
 func (s DrainerConfigStatus) NewTimeoutCondition() DrainerConfigStatusCondition {
 	return DrainerConfigStatusCondition{
+		LastHeartbeatTime:  metav1.Now(),
 		LastTransitionTime: metav1.Now(),
 		Status:             DrainerConfigStatusStatusTrue,
 		Type:               DrainerConfigStatusTypeTimeout,


### PR DESCRIPTION
It is invalid to create a `Condition` with a `nil` `LastHeartbeatTime`, so this adds one. I think this was just missed when the equivalent timestamp for `LastTransitionTime` was added.

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
