### PR TITLE
Add appCatalogEntry into registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `AppCatalogEntry` into the registry.
+
 ## [3.18.2] - 2021-02-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `AppCatalogEntry` into the registry.
+- Register `AppCatalogEntry` CRD as a known type.
 
 ## [3.18.2] - 2021-02-18
 

--- a/pkg/apis/application/v1alpha1/register.go
+++ b/pkg/apis/application/v1alpha1/register.go
@@ -17,6 +17,8 @@ const (
 var knownTypes = []runtime.Object{
 	&AppCatalog{},
 	&AppCatalogList{},
+	&AppCatalogEntry{},
+	&AppCatalogEntryList{},
 	&App{},
 	&AppList{},
 	&Chart{},


### PR DESCRIPTION
We need to add new CRDs into the registry to use it from unittest. 
Otherwise, we get an error below. 
```
    --- FAIL: Test_ValidateMetadataConstraints/case_1:_fixed_namespace_constraint (0.00s)
panic: no kind is registered for the type v1alpha1.AppCatalogEntry in scheme "pkg/runtime/scheme.go:101" [recovered]
	panic: no kind is registered for the type v1alpha1.AppCatalogEntry in scheme "pkg/runtime/scheme.go:101"
```

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
