### PR TITLE
Add CAPI labels that will be used to filter CR's by version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Cluster API labels that will be used to filter CR's by version.
+
 ### Changed
 
 - Terminology update to use 'workload cluster release' consistently.

--- a/pkg/label/version.go
+++ b/pkg/label/version.go
@@ -30,6 +30,30 @@ const AWSOperatorVersion = "aws-operator.giantswarm.io/version"
 // that there is an azure-operator release v4.1.0.
 const AzureOperatorVersion = "azure-operator.giantswarm.io/version"
 
+// CAPIVersion is the version label put into provider independent CRs
+// to define which cluster-api-core version should reconcile the given CR.
+const CAPIVersion = "cluster-api.giantswarm.io/version"
+
+// CABPKVersion is the version label put into bootstrap CRs
+// to define which cluster-api-bootstrap-provider-kubeadm version should reconcile the given CR.
+const CABPKVersion = "cluster-api-bootstrap-kubeadm.giantswarm.io/version"
+
+// CACPKVersion is the version label put into control plane CRs
+// to define which cluster-api-control-plane-kubeadm version should reconcile the given CR.
+const CACPKVersion = "cluster-api-control-plane-kubeadm.giantswarm.io/version"
+
+// CAPAVersion is the version label put into AWS CRs
+// to define which CAPA version should reconcile the given CR.
+const CAPAVersion = "cluster-api-provider-aws.giantswarm.io/version"
+
+// CAPZVersion is the version label put into Azure CRs
+// to define which CAPZ version should reconcile the given CR.
+const CAPZVersion = "cluster-api-provider-azure.giantswarm.io/version"
+
+// ClusterOperatorVersion is the version label put into VSphere CRs
+// to define which CAPV version should reconcile the given CR.
+const CAPVVersion = "cluster-api-provider-vsphere.giantswarm.io/version"
+
 // ClusterOperatorVersion is the version label put into provider independent CRs
 // to define which cluster-operator version should reconcile the given CR.
 // Versions are defined as semver version without the "v" prefix, e.g. 2.3.0,


### PR DESCRIPTION
We need to filter which CRs are watched by each deployed CAPI controller. The filtering is done via label.

Kubernetes label max length is 63 chars, we are safe.

## Checklist

- [ ] Consider SIG UX feedback.
- [X] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
