### PR TITLE
Refactor ID generation to block ids starting with digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add shortnames `org` and `orgs` for CRD `organizations.security.giantswarm.io`.
+- Disallow generated IDs to start with digits.
 
 ### Changed
 

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -28,9 +28,7 @@ func Generate() string {
 		}
 
 		id := string(b)
-		matched := idRegexp.MatchString(id)
-
-		if !matched {
+		if !idRegexp.MatchString(id) {
 			continue
 		}
 

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -14,10 +14,12 @@ const (
 	IDLength = 5
 )
 
-func Generate() string {
-	idRegexp := regexp.MustCompile("^[a-z]([a-z][0-9]|[0-9][a-z])+$")
-	letterRunes := []rune(IDChars)
+var (
+	idRegexp    = regexp.MustCompile("^[a-z]([a-z][0-9]|[0-9][a-z])+$")
+	letterRunes = []rune(IDChars)
+)
 
+func Generate() string {
 	b := make([]rune, IDLength)
 	for {
 		rand.Seed(time.Now().UnixNano())

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -3,7 +3,6 @@ package id
 import (
 	"math/rand"
 	"regexp"
-	"strconv"
 	"time"
 )
 
@@ -16,26 +15,20 @@ const (
 )
 
 func Generate() string {
-	compiledRegexp, _ := regexp.Compile("^[a-z]+$")
+	idRegexp := regexp.MustCompile("^[a-z]([a-z][0-9]|[0-9][a-z])+$")
+	letterRunes := []rune(IDChars)
 
+	b := make([]rune, IDLength)
 	for {
-		letterRunes := []rune(IDChars)
-		b := make([]rune, IDLength)
 		rand.Seed(time.Now().UnixNano())
 		for i := range b {
 			b[i] = letterRunes[rand.Intn(len(letterRunes))]
 		}
 
 		id := string(b)
+		matched := idRegexp.MatchString(id)
 
-		if _, err := strconv.Atoi(id); err == nil {
-			// ID is made up of numbers only, which we want to avoid.
-			continue
-		}
-
-		matched := compiledRegexp.MatchString(id)
-		if matched {
-			// ID is made up of letters only, which we also avoid.
+		if !matched {
 			continue
 		}
 

--- a/pkg/id/id_test.go
+++ b/pkg/id/id_test.go
@@ -24,7 +24,7 @@ func TestGenerate(t *testing.T) {
 			}
 
 			if !unicode.IsLetter(idChars[0]) {
-				t.Fatalf("generated id starts does not start with a letter: %q", id)
+				t.Fatalf("generated id does not start with a letter: %q", id)
 			}
 
 			if lettersOnlyRegexp.MatchString(id) {

--- a/pkg/id/id_test.go
+++ b/pkg/id/id_test.go
@@ -34,6 +34,10 @@ func TestGenerate(t *testing.T) {
 			if digitsOnlyRegexp.MatchString(id) {
 				t.Fatalf("generated id only contains digits: %q", id)
 			}
+
+			if len(idChars) > IDLength {
+				t.Fatalf("generated id is too long: %d > %d", len(idChars), IDLength)
+			}
 		})
 	}
 }

--- a/pkg/id/id_test.go
+++ b/pkg/id/id_test.go
@@ -1,0 +1,39 @@
+package id
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+	"unicode"
+)
+
+func TestGenerate(t *testing.T) {
+	attempts := 1000
+
+	validCharsRegexp := regexp.MustCompile("^[02-9a-km-z]")
+	lettersOnlyRegexp := regexp.MustCompile("^[a-z]+$")
+	digitsOnlyRegexp := regexp.MustCompile("^[0-9]+$")
+
+	for i := 0; i < attempts; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			id := Generate()
+			idChars := []rune(id)
+
+			if !validCharsRegexp.MatchString(id) {
+				t.Fatalf("generated id contains invalid characters: %q", id)
+			}
+
+			if !unicode.IsLetter(idChars[0]) {
+				t.Fatalf("generated id starts does not start with a letter: %q", id)
+			}
+
+			if lettersOnlyRegexp.MatchString(id) {
+				t.Fatalf("generated id only contains letters: %q", id)
+			}
+
+			if digitsOnlyRegexp.MatchString(id) {
+				t.Fatalf("generated id only contains digits: %q", id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16193

This PR makes generated IDs not be able to start with digits. It also simplifies the previous implementation.

`api` and `kubectl-gs` should be updated to use this new generator.