### PR TITLE
Document original-organization-name annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the `ui.giantswarm.io/original-organization-name` annotation
+
 ## [3.22.0] - 2021-03-17
 
 ### Added

--- a/pkg/annotation/organization.go
+++ b/pkg/annotation/organization.go
@@ -1,0 +1,9 @@
+package annotation
+
+// support:
+//   - crd: organization.security.giantswarm.io
+//     apiversion: v1alpha1
+// documentation:
+//   This annotation contains the original name of organizations migrated from
+//   our legacy organization management service.
+const UIOrganizationOriginalName = "ui.giantswarm.io/original-organization-name"

--- a/pkg/annotation/organization.go
+++ b/pkg/annotation/organization.go
@@ -6,4 +6,4 @@ package annotation
 // documentation:
 //   This annotation contains the original name of organizations migrated from
 //   our legacy organization management service.
-const UIOrganizationOriginalName = "ui.giantswarm.io/original-organization-name"
+const UIOriginalOrganizationName = "ui.giantswarm.io/original-organization-name"


### PR DESCRIPTION
We want to migrate fully to Organization CR's as the source of truth for Organizations, while delaying the task of figuring out how to migrate related resources.

Unfortunately, some organisations have a name that is incompatible with Organization CR's validation for names. That means, in order not to lose data, we will store that name into an annotation. This will let our UI's operate as normal, and further the transition to the MAPI.