### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/helm/apiextensions-app-e2e-chart/values.yaml
+++ b/helm/apiextensions-app-e2e-chart/values.yaml
@@ -26,7 +26,7 @@ appCatalogs:
     logoUrl: "http://giantswarm.com/catalog-logo.png"
     storage:
       type: "helm"
-      url: "https://giantswarm.github.com/sample-catalog/"
+      url: "https://giantswarm.github.io/sample-catalog/"
 
 configMaps:
   app-values:


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898