### PR TITLE
cabundle

### DIFF
--- a/hack/build-charts.go
+++ b/hack/build-charts.go
@@ -132,6 +132,9 @@ func downloadReleaseAssetCRDs(ctx context.Context, client *github.Client, asset 
 
 func patchCAPIWebhook(crd *v1.CustomResourceDefinition) {
 	port := int32(9443)
+	if _, ok := crd.Annotations["cert-manager.io/inject-ca-from"]; ok {
+		crd.Annotations["cert-manager.io/inject-ca-from"] = "giantswarm/cluster-api-core-unique-webhook"
+	}
 	crd.Spec.Conversion = &v1.CustomResourceConversion{
 		Strategy: v1.WebhookConverter,
 		Webhook: &v1.WebhookConversion{
@@ -154,6 +157,9 @@ func patchCAPIWebhook(crd *v1.CustomResourceDefinition) {
 
 func patchCAPAWebhook(crd *v1.CustomResourceDefinition) {
 	port := int32(9443)
+	if _, ok := crd.Annotations["cert-manager.io/inject-ca-from"]; ok {
+		crd.Annotations["cert-manager.io/inject-ca-from"] = "giantswarm/cluster-api-provider-aws-unique-webhook"
+	}
 	crd.Spec.Conversion = &v1.CustomResourceConversion{
 		Strategy: v1.WebhookConverter,
 		Webhook: &v1.WebhookConversion{

--- a/hack/build-charts.go
+++ b/hack/build-charts.go
@@ -142,7 +142,7 @@ func patchCAPIWebhook(crd *v1.CustomResourceDefinition) {
 					Path:      to.StringP("/convert"),
 					Port:      &port,
 				},
-				CABundle: []byte("Cg=="),
+				CABundle: []byte("\n"),
 			},
 			ConversionReviewVersions: []string{
 				"v1",
@@ -164,7 +164,7 @@ func patchCAPAWebhook(crd *v1.CustomResourceDefinition) {
 					Path:      to.StringP("/convert"),
 					Port:      &port,
 				},
-				CABundle: []byte("Cg=="),
+				CABundle: []byte("\n"),
 			},
 			ConversionReviewVersions: []string{
 				"v1",

--- a/helm/crds-aws/templates/upstream.yaml
+++ b/helm/crds-aws/templates/upstream.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capa-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -106,7 +106,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capa-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -253,7 +253,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capa-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -1882,7 +1882,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capa-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -2445,7 +2445,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capa-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:

--- a/helm/crds-aws/templates/upstream.yaml
+++ b/helm/crds-aws/templates/upstream.yaml
@@ -14,7 +14,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -118,7 +118,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -265,7 +265,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -1230,7 +1230,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -1345,7 +1345,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -1504,7 +1504,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -1894,7 +1894,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -2457,7 +2457,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -2922,7 +2922,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm
@@ -3042,7 +3042,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-provider-aws-unique-webhook
           namespace: giantswarm

--- a/helm/crds-common/templates/upstream.yaml
+++ b/helm/crds-common/templates/upstream.yaml
@@ -239,7 +239,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-core-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -596,7 +596,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-core-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -1254,7 +1254,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-core-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -1836,7 +1836,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-core-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -2322,7 +2322,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-core-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:

--- a/helm/crds-common/templates/upstream.yaml
+++ b/helm/crds-common/templates/upstream.yaml
@@ -250,7 +250,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-core-unique-webhook
           namespace: giantswarm
@@ -607,7 +607,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-core-unique-webhook
           namespace: giantswarm
@@ -1265,7 +1265,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-core-unique-webhook
           namespace: giantswarm
@@ -1847,7 +1847,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-core-unique-webhook
           namespace: giantswarm
@@ -2333,7 +2333,7 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Q2c9PQ==
+        caBundle: Cg==
         service:
           name: cluster-api-core-unique-webhook
           namespace: giantswarm


### PR DESCRIPTION
This pr adds some minor changes to @tfussell PR. It will change the CABundle from conversion like we in [aws-admission-controller](https://github.com/giantswarm/aws-admission-controller/blob/master/helm/aws-admission-controller/templates/webhook.yaml#L20). Leave it more or less empty to let cert-manager inject it.

This PR also changes the inject-ca from the corresponding webhook in the `giantswarm` namespace instead of capi / capa namespaces. For now we assume the capa webhook is called `cluster-api-provider-aws-unique-webhook` which is responsible for **CRD** migration.

/cc @anvddriesch 

## Checklist

- [ ] Consider SIG UX feedback.
- [ ] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).
