### PR TITLE
Add EKS to AWS upstream CRD collection

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,2 @@
+# Ignore CVE jwt-go before 4.0.0-preview1 allows attackers to bypass intended access restrict...https://github.com/dgrijalva/jwt-go/issues/290
+CVE-2020-26160 until=2021-06-01

--- a/hack/build-charts.go
+++ b/hack/build-charts.go
@@ -209,7 +209,10 @@ var patches = map[string]func(crd *v1.CustomResourceDefinition){
 	"awsmachines.infrastructure.cluster.x-k8s.io":                    patchCAPAWebhook,
 	"awsmachinetemplates.infrastructure.cluster.x-k8s.io":            patchCAPAWebhook,
 	"awsmanagedclusters.infrastructure.cluster.x-k8s.io":             patchCAPAWebhook,
+	"awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io":          patchCAPAWebhook,
 	"awsmanagedmachinepools.infrastructure.cluster.x-k8s.io":         patchCAPAWebhook,
+	"eksconfigs.bootstrap.cluster.x-k8s.io":                          patchCAPAWebhook,
+	"eksconfigtemplates.bootstrap.cluster.x-k8s.io":                  patchCAPAWebhook,
 	"releases.release.giantswarm.io":                                 patchReleaseValidation,
 }
 

--- a/hack/build-charts.go
+++ b/hack/build-charts.go
@@ -188,6 +188,56 @@ func patchCAPAWebhook(crd *v1.CustomResourceDefinition) {
 	}
 }
 
+func patchEKSControlPlaneWebhook(crd *v1.CustomResourceDefinition) {
+	port := int32(9443)
+	if _, ok := crd.Annotations["cert-manager.io/inject-ca-from"]; ok {
+		crd.Annotations["cert-manager.io/inject-ca-from"] = "giantswarm/cluster-api-provider-aws-eks-controlplane-unique-webhook"
+	}
+	crd.Spec.Conversion = &v1.CustomResourceConversion{
+		Strategy: v1.WebhookConverter,
+		Webhook: &v1.WebhookConversion{
+			ClientConfig: &v1.WebhookClientConfig{
+				Service: &v1.ServiceReference{
+					Namespace: "giantswarm",
+					Name:      "cluster-api-provider-aws-eks-controlplane-unique-webhook",
+					Path:      to.StringP("/convert"),
+					Port:      &port,
+				},
+				CABundle: []byte("\n"),
+			},
+			ConversionReviewVersions: []string{
+				"v1",
+				"v1beta1",
+			},
+		},
+	}
+}
+
+func patchEKSConfigWebhook(crd *v1.CustomResourceDefinition) {
+	port := int32(9443)
+	if _, ok := crd.Annotations["cert-manager.io/inject-ca-from"]; ok {
+		crd.Annotations["cert-manager.io/inject-ca-from"] = "giantswarm/cluster-api-provider-aws-eks-config-unique-webhook"
+	}
+	crd.Spec.Conversion = &v1.CustomResourceConversion{
+		Strategy: v1.WebhookConverter,
+		Webhook: &v1.WebhookConversion{
+			ClientConfig: &v1.WebhookClientConfig{
+				Service: &v1.ServiceReference{
+					Namespace: "giantswarm",
+					Name:      "cluster-api-provider-aws-eks-config-unique-webhook",
+					Path:      to.StringP("/convert"),
+					Port:      &port,
+				},
+				CABundle: []byte("\n"),
+			},
+			ConversionReviewVersions: []string{
+				"v1",
+				"v1beta1",
+			},
+		},
+	}
+}
+
 func patchReleaseValidation(crd *v1.CustomResourceDefinition) {
 	for i := range crd.Spec.Versions {
 		crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["metadata"] = v1.JSONSchemaProps{
@@ -217,10 +267,10 @@ var patches = map[string]func(crd *v1.CustomResourceDefinition){
 	"awsmachines.infrastructure.cluster.x-k8s.io":                    patchCAPAWebhook,
 	"awsmachinetemplates.infrastructure.cluster.x-k8s.io":            patchCAPAWebhook,
 	"awsmanagedclusters.infrastructure.cluster.x-k8s.io":             patchCAPAWebhook,
-	"awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io":          patchCAPAWebhook,
+	"awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io":          patchEKSControlPlaneWebhook,
 	"awsmanagedmachinepools.infrastructure.cluster.x-k8s.io":         patchCAPAWebhook,
-	"eksconfigs.bootstrap.cluster.x-k8s.io":                          patchCAPAWebhook,
-	"eksconfigtemplates.bootstrap.cluster.x-k8s.io":                  patchCAPAWebhook,
+	"eksconfigs.bootstrap.cluster.x-k8s.io":                          patchEKSConfigWebhook,
+	"eksconfigtemplates.bootstrap.cluster.x-k8s.io":                  patchEKSConfigWebhook,
 	"releases.release.giantswarm.io":                                 patchReleaseValidation,
 }
 

--- a/helm/crds-aws/templates/upstream.yaml
+++ b/helm/crds-aws/templates/upstream.yaml
@@ -6,6 +6,1061 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
+    cluster.x-k8s.io/provider: bootstrap-eks
+    cluster.x-k8s.io/v1alpha2: v1alpha2
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: eksconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: cluster-api-provider-aws-unique-webhook
+          namespace: giantswarm
+          path: /convert
+          port: 9443
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: EKSConfig
+    listKind: EKSConfigList
+    plural: eksconfigs
+    singular: eksconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Bootstrap configuration is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Name of Secret containing bootstrap data
+      jsonPath: .status.dataSecretName
+      name: DataSecretName
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: EKSConfig is the Schema for the eksconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigSpec defines the desired state of EKSConfig
+            properties:
+              kubeletExtraArgs:
+                additionalProperties:
+                  type: string
+                description: Passes the kubelet args into the EKS bootstrap script
+                type: object
+            type: object
+          status:
+            description: EKSConfigStatus defines the observed state of EKSConfig
+            properties:
+              conditions:
+                description: Conditions defines current service state of the EKSConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData secret is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-eks
+    cluster.x-k8s.io/v1alpha2: v1alpha2
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: eksconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: cluster-api-provider-aws-unique-webhook
+          namespace: giantswarm
+          path: /convert
+          port: 9443
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: EKSConfigTemplate
+    listKind: EKSConfigTemplateList
+    plural: eksconfigtemplates
+    singular: eksconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: EKSConfigTemplate is the Schema for the eksconfigtemplates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigTemplateSpec defines the desired state of EKSConfigTemplate
+            properties:
+              template:
+                description: EKSConfigTemplateResource defines the Template structure
+                properties:
+                  spec:
+                    description: EKSConfigSpec defines the desired state of EKSConfig
+                    properties:
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: Passes the kubelet args into the EKS bootstrap script
+                        type: object
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-eks
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: cluster-api-provider-aws-unique-webhook
+          namespace: giantswarm
+          path: /convert
+          port: 9443
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSManagedControlPlane
+    listKind: AWSManagedControlPlaneList
+    plural: awsmanagedcontrolplanes
+    shortNames:
+    - awsmcp
+    singular: awsmanagedcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSManagedControl belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Control plane infrastructure is ready for worker nodes
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: AWS VPC the control plane is using
+      jsonPath: .spec.networkSpec.vpc.id
+      name: VPC
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion IP address for breakglass access
+      jsonPath: .status.bastion.publicIp
+      name: Bastion IP
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSManagedControlPlane is the Schema for the awsmanagedcontrolplanes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.
+                type: object
+              addons:
+                description: Addons defines the EKS addons to enable with the EKS cluster.
+                items:
+                  description: Addon represents a EKS addon
+                  properties:
+                    conflictResolution:
+                      default: none
+                      description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none
+                      enum:
+                      - overwrite
+                      - none
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      minLength: 2
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              associateOIDCProvider:
+                default: false
+                description: AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts
+                type: boolean
+              bastion:
+                description: Bastion contains options to configure the bastion host.
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                    items:
+                      type: string
+                    type: array
+                  ami:
+                    description: AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.
+                    type: string
+                  disableIngressRules:
+                    description: DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.
+                    type: boolean
+                  enabled:
+                    description: Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.
+                    type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.
+                    type: string
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              disableVPCCNI:
+                default: false
+                description: DisableVPCCNI indcates the the Amazon VPC CNI should be disabled. With EKS clusters that the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon or if you have specified a secondary CIDR block.
+                type: boolean
+              eksClusterName:
+                description: EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.
+                type: string
+              encryptionConfig:
+                description: EncryptionConfig specifies the encryption configuration for the cluster
+                properties:
+                  provider:
+                    description: Provider specifies the ARN or alias of the CMK (in AWS KMS)
+                    type: string
+                  resources:
+                    description: Resources specifies the resources to be encrypted
+                    items:
+                      type: string
+                    type: array
+                type: object
+              endpointAccess:
+                description: Endpoints specifies access to this cluster's control plane endpoints
+                properties:
+                  private:
+                    description: Private points VPC-internal control plane access to the private endpoint
+                    type: boolean
+                  public:
+                    description: Public controls whether control plane endpoints are publicly accessible
+                    type: boolean
+                  publicCIDRs:
+                    description: PublicCIDRs specifies which blocks can access the public endpoint
+                    items:
+                      type: string
+                    type: array
+                type: object
+              iamAuthenticatorConfig:
+                description: IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.
+                properties:
+                  mapRoles:
+                    description: RoleMappings is a list of role mappings
+                    items:
+                      description: RoleMapping represents a mapping from a IAM role to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        rolearn:
+                          description: RoleARN is the AWS ARN for the role to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - rolearn
+                      - username
+                      type: object
+                    type: array
+                  mapUsers:
+                    description: UserMappings is a list of user mappings
+                    items:
+                      description: UserMapping represents a mapping from an IAM user to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        userarn:
+                          description: UserARN is the AWS ARN for the user to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - userarn
+                      - username
+                      type: object
+                    type: array
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when reconciling the managed control plane.
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.
+                type: string
+              logging:
+                description: Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch
+                properties:
+                  apiServer:
+                    default: false
+                    description: APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled
+                    type: boolean
+                  audit:
+                    default: false
+                    description: Audit indicates if the Kubernetes API audit log should be enabled
+                    type: boolean
+                  authenticator:
+                    default: false
+                    description: Authenticator indicates if the iam authenticator log should be enabled
+                    type: boolean
+                  controllerManager:
+                    default: false
+                    description: ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled
+                    type: boolean
+                  scheduler:
+                    default: false
+                    description: Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled
+                    type: boolean
+                required:
+                - apiServer
+                - audit
+                - authenticator
+                - controllerManager
+                - scheduler
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  cni:
+                    description: CNI configuration
+                    properties:
+                      cniIngressRules:
+                        description: CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.
+                        items:
+                          description: CNIIngressRule defines an AWS ingress rule for CNI requirements.
+                          properties:
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                              type: string
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                    type: object
+                  securityGroupOverrides:
+                    additionalProperties:
+                      type: string
+                    description: SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster
+                    type: object
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      availabilityZoneSelection:
+                        default: Ordered
+                        description: 'AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered'
+                        enum:
+                        - Ordered
+                        - Random
+                        type: string
+                      availabilityZoneUsageLimit:
+                        default: 3
+                        description: AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3
+                        minimum: 1
+                        type: integer
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              roleAdditionalPolicies:
+                description: RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.
+                items:
+                  type: string
+                type: array
+              roleName:
+                description: RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.
+                minLength: 2
+                type: string
+              secondaryCidrBlock:
+                description: SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+              tokenMethod:
+                default: iam-authenticator
+                description: TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator
+                enum:
+                - iam-authenticator
+                - aws-cli
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?$
+                type: string
+            type: object
+          status:
+            description: AWSManagedControlPlaneStatus defines the observed state of AWSManagedControlPlane
+            properties:
+              addons:
+                description: Addons holds the current status of the EKS addons
+                items:
+                  description: AddonState represents the state of an addon
+                  properties:
+                    arn:
+                      description: ARN is the AWS ARN of the addon
+                      type: string
+                    createdAt:
+                      description: CreatedAt is the date and time the addon was created at
+                      format: date-time
+                      type: string
+                    issues:
+                      description: Issues is a list of issue associated with the addon
+                      items:
+                        description: AddonIssue represents an issue with an addon
+                        properties:
+                          code:
+                            description: Code is the issue code
+                            type: string
+                          message:
+                            description: Message is the textual description of the issue
+                            type: string
+                          resourceIds:
+                            description: ResourceIDs is a list of resource ids for the issue
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    modifiedAt:
+                      description: ModifiedAt is the date and time the addon was last modified
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of the IAM role used for the service account
+                      type: string
+                    status:
+                      description: Status is the status of the addon
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - arn
+                  - name
+                  - version
+                  type: object
+                type: array
+              bastion:
+                description: Bastion holds details of the instance that is used as a bastion jump box
+                properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: MachineAddress contains information for the node's address.
+                      properties:
+                        address:
+                          description: The machine address.
+                          type: string
+                        type:
+                          description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    description: Availability zone of instance
+                    type: string
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for the storage device
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted or not.
+                          type: boolean
+                        encryptionKey:
+                          description: EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1, etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance, if applicable.
+                    type: string
+                  rootVolume:
+                    description: Configuration options for the root storage volume.
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1, etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  spotMarketOptions:
+                    description: SpotMarketOptions option for configuring instances to be run using AWS Spot instances.
+                    properties:
+                      maxPrice:
+                        description: MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
+                        type: string
+                    type: object
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared or single-tenant hardware.
+                    type: string
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              conditions:
+                description: Conditions specifies the cpnditions for the managed control plane
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalManagedControlPlane:
+                default: true
+                description: ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains specifies a list fo available availability zones that can be used
+                type: object
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.
+                type: boolean
+              network:
+                description: Networks holds details about the AWS networking resources used by the control plane
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated with the load balancer.
+                        properties:
+                          crossZoneLoadBalancing:
+                            description: CrossZoneLoadBalancing enables the classic load balancer load balancing.
+                            type: boolean
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      availabilityZones:
+                        description: AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the security group to its unique name, if any.
+                    type: object
+                type: object
+              oidcProvider:
+                description: OIDCProvider holds the status of the identity provider for this cluster
+                properties:
+                  arn:
+                    description: ARN holds the ARN of the provider
+                    type: string
+                  trustPolicy:
+                    description: TrustPolicy contains the boilerplate IAM trust policy to use for IRSA
+                    type: string
+                type: object
+              ready:
+                default: false
+                description: Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  labels:
     cluster.x-k8s.io/provider: infrastructure-aws
     cluster.x-k8s.io/v1alpha3: v1alpha3
   name: awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io

--- a/helm/crds-aws/templates/upstream.yaml
+++ b/helm/crds-aws/templates/upstream.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-eks-config-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -17,7 +17,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: cluster-api-provider-aws-unique-webhook
+          name: cluster-api-provider-aws-eks-config-unique-webhook
           namespace: giantswarm
           path: /convert
           port: 9443
@@ -131,7 +131,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-eks-config-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -146,7 +146,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: cluster-api-provider-aws-unique-webhook
+          name: cluster-api-provider-aws-eks-config-unique-webhook
           namespace: giantswarm
           path: /convert
           port: 9443
@@ -210,7 +210,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-unique-webhook
+    cert-manager.io/inject-ca-from: giantswarm/cluster-api-provider-aws-eks-controlplane-unique-webhook
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
   labels:
@@ -224,7 +224,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: cluster-api-provider-aws-unique-webhook
+          name: cluster-api-provider-aws-eks-controlplane-unique-webhook
           namespace: giantswarm
           path: /convert
           port: 9443


### PR DESCRIPTION
This PR supports multiple Github asset files to include EKS bootstrap and controlplane components because it is not included in `infrastructure.yaml`.

CRDs which are added:

- eksconfigs.bootstrap.cluster.x-k8s.io
- eksconfigtemplates.bootstrap.cluster.x-k8s.io
- awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io

Additionally I had to add EKS config and EKS controlplane webhook for CRD conversion because they are in new API groups.

## Checklist

- [ ] Consider SIG UX feedback.
- [ ] Update changelog in CHANGELOG.md.
- [ ] If adding a new type, ensure that it is added to the [CRD unit tests](https://github.com/giantswarm/apiextensions/blob/d78aba91d578d56ef49f58e336035d35edc4e1b0/pkg/crd/crd_test.go#L9).