### PR TITLE
remove-alpha-prefix-for-node-termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `alpha` prefix from `NodeTerminateUnhealthy` annotation.
+
 ## [3.24.0] - 2021-05-18
 
 ### Added

--- a/pkg/annotation/nodeautomation.go
+++ b/pkg/annotation/nodeautomation.go
@@ -1,4 +1,4 @@
 package annotation
 
 // Annotation used to enable feature to terminate unhealthy nodes on a cluster CR.
-const NodeTerminateUnhealthy = "alpha.node.giantswarm.io/terminate-unhealthy"
+const NodeTerminateUnhealthy = "node.giantswarm.io/terminate-unhealthy"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/16843

remove `alpha` prefix for the feature