### PR TITLE
Store docs metadata and config on CRDs in apiextensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Move CRD metadata for [docs.giantswarm.io](https://docs.giantswarm.io/ui-api/management-api/crd/) into this repository.
+
 ### Fixed
 
 - Typo in certconfigs.core.giantswarm.io/v1alpha1

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,0 +1,158 @@
+# This file contains configuration and metadata for the CRD schema documentation
+# at https://docs.giantswarm.io/ui-api/management-api/crd/
+#
+# Schema:
+#
+# .crds.*: Each key is a full CRD name.
+# .crds.*.owner: List of URLs of teams owning the CRD.
+# .crds.*.topics:
+#   array of strings. Possible values:
+#   - apps: related to managed apps
+#   - managementcluster - deals with the management cluster.
+#   - workloadcluster - deals with workload clusters.
+# .crds.*.provider: array of strings. Possible values:
+#   - aws
+#   - azure
+# .crds.*.publish: Set to false to disable in docs. Defaults is true.
+#
+crds:
+  appcatalogs.application.giantswarm.io:
+    topics:
+      - apps
+  appcatalogentries.application.giantswarm.io:
+    topics:
+      - apps
+  apps.application.giantswarm.io:
+    topics:
+      - apps
+  awsclusters.infrastructure.giantswarm.io:
+    provider:
+      - aws
+    topics:
+      - workloadcluster
+  awsclusterconfigs.core.giantswarm.io:
+    publish: false
+  awsconfigs.provider.giantswarm.io:
+    publish: false
+  awscontrolplanes.infrastructure.giantswarm.io:
+    provider:
+      - aws
+    topics:
+      - workloadcluster
+  awsmachinedeployments.infrastructure.giantswarm.io:
+    provider:
+      - aws
+    topics:
+      - workloadcluster
+  azureclusters.infrastructure.cluster.x-k8s.io:
+    provider:
+      - azure
+    topics:
+      - workloadcluster
+  azureclusterconfigs.core.giantswarm.io:
+    publish: false
+  azureconfigs.provider.giantswarm.io:
+    publish: false
+  azuremachinepools.exp.infrastructure.cluster.x-k8s.io:
+    provider:
+      - azure
+    topics:
+      - workloadcluster
+  azuremachines.infrastructure.cluster.x-k8s.io:
+    provider:
+      - azure
+    topics:
+      - workloadcluster
+  azuretools.tooling.giantswarm.io:
+    publish: false
+  certconfigs.core.giantswarm.io:
+    topics:
+      - managementcluster
+      - workloadcluster
+  charts.application.giantswarm.io:
+    topics:
+      - apps
+  chartconfigs.core.giantswarm.io:
+    publish: false
+  clusters.core.giantswarm.io:
+    publish: false
+  clusters.cluster.x-k8s.io:
+    provider:
+      - aws
+      - azure
+    topics:
+      - workloadcluster
+  configs.core.giantswarm.io:
+    topics:
+      - apps
+      - managementcluster
+  drainerconfigs.core.giantswarm.io:
+    publish: false
+  draughtsmanconfigs.core.giantswarm.io:
+    publish: false
+  etcdbackups.backup.giantswarm.io:
+    publish: false
+  flannelconfigs.core.giantswarm.io:
+    publish: false
+  g8scontrolplanes.infrastructure.giantswarm.io:
+    provider:
+      - aws
+    topics:
+      - workloadcluster
+  ignitions.core.giantswarm.io:
+    topics:
+      - managementcluster
+      - workloadcluster
+  ingressconfigs.core.giantswarm.io:
+    publish: false
+  kvmclusterconfigs.core.giantswarm.io:
+    provider:
+      - kvm
+    topics:
+      - workloadcluster
+  kvmconfigs.provider.giantswarm.io:
+    provider:
+      - kvm
+    topics:
+      - workloadcluster
+  machinepools.exp.cluster.x-k8s.io:
+    provider:
+      - azure
+    topics:
+      - workloadcluster
+  memcachedconfigs.example.giantswarm.io:
+    publish: false
+  networkpools.infrastructure.giantswarm.io:
+    provider:
+      - aws
+    topics:
+      - workloadcluster
+  organizations.security.giantswarm.io:
+    topics:
+      - managementcluster
+  releasecycles.release.giantswarm.io:
+    publish: false
+  releases.release.giantswarm.io:
+    topics:
+      - managementcluster
+      - workloadcluster
+  silences.monitoring.giantswarm.io:
+    topics:
+      - managementcluster
+  sparks.core.giantswarm.io:
+    provider:
+      - azure
+    topics:
+      - workloadcluster
+  storageconfigs.core.giantswarm.io:
+    publish: false
+    topics:
+      - managementcluster
+  vsphereclusters.infrastructure.cluster.x-k8s.io:
+    publish: false
+  vspheremachines.infrastructure.cluster.x-k8s.io:
+    publish: false
+  vspheremachinetemplates.infrastructure.cluster.x-k8s.io:
+    publish: false
+  vspherevms.infrastructure.cluster.x-k8s.io:
+    publish: false

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,6 +1,8 @@
 # This file contains configuration and metadata for the CRD schema documentation
 # at https://docs.giantswarm.io/ui-api/management-api/crd/
 #
+# Only CRDs contained here will be published.
+#
 # Schema:
 #
 # .crds.*: Each key is a full CRD name.

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -274,7 +274,12 @@ crds:
     topics:
       - workloadcluster
   machinedeployments.cluster.x-k8s.io:
-    hidden: true
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    provider:
+      - aws
+    topics:
+      - workloadcluster
   machinehealthchecks.cluster.x-k8s.io:
     hidden: true
   machinepools.exp.cluster.x-k8s.io:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -13,7 +13,7 @@
 # .crds.*.provider: array of strings. Possible values:
 #   - aws
 #   - azure
-# .crds.*.publish: Set to false to disable in docs. Defaults is true.
+# .crds.*.hidden: Set to true to disable in docs. Default is false.
 #
 crds:
   appcatalogs.application.giantswarm.io:
@@ -46,7 +46,16 @@ crds:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true
+  awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io:
+    awsclusterroleidentities.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   awsclusterroleidentities.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  awsclusterstaticidentities.infrastructure.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true
@@ -61,6 +70,10 @@ crds:
       - aws
     topics:
       - workloadcluster
+  awsfargateprofiles.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   awsmachinedeployments.infrastructure.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
@@ -72,9 +85,33 @@ crds:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true
+  awsmachines.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   awsmachinetemplates.infrastructure.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  awsmanagedclusters.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  awsmanagedmachinepools.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  azureassignedidentities.aadpodidentity.k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azureclusteridentities.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     hidden: true
   azureclusters.infrastructure.cluster.x-k8s.io:
     owner:
@@ -88,6 +125,14 @@ crds:
       - https://github.com/orgs/giantswarm/teams/team-celestial
     hidden: true
   azureconfigs.provider.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azureidentities.aadpodidentity.k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azureidentitybindings.aadpodidentity.k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
     hidden: true
@@ -105,6 +150,26 @@ crds:
       - azure
     topics:
       - workloadcluster
+  azuremachinetemplates.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azuremanagedclusters.exp.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azuremanagedcontrolplanes.exp.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azuremanagedmachinepools.exp.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
+  azurepodidentityexceptions.aadpodidentity.k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+    hidden: true
   azuretools.tooling.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
@@ -127,6 +192,10 @@ crds:
       - apps
   chartconfigs.core.giantswarm.io:
     hidden: true
+  clusterresourcesetbindings.addons.cluster.x-k8s.io:
+    hidden: true
+  clusterresourcesets.addons.cluster.x-k8s.io:
+    hidden: true
   clusters.core.giantswarm.io:
     hidden: true
   clusters.cluster.x-k8s.io:
@@ -148,6 +217,14 @@ crds:
     hidden: true
   draughtsmanconfigs.core.giantswarm.io:
     hidden: true
+  eksconfigs.bootstrap.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  eksconfigtemplates.bootstrap.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   etcdbackups.backup.giantswarm.io:
     hidden: true
   flannelconfigs.core.giantswarm.io:
@@ -159,6 +236,8 @@ crds:
       - aws
     topics:
       - workloadcluster
+  haproxyloadbalancers.infrastructure.cluster.x-k8s.io:
+    hidden: true
   ignitions.core.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-ludacris
@@ -168,6 +247,10 @@ crds:
   ingressconfigs.core.giantswarm.io:
     hidden: true
   kubeadmconfigs.bootstrap.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true
@@ -189,6 +272,10 @@ crds:
       - kvm
     topics:
       - workloadcluster
+  machinedeployments.cluster.x-k8s.io:
+    hidden: true
+  machinehealthchecks.cluster.x-k8s.io:
+    hidden: true
   machinepools.exp.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
@@ -196,6 +283,10 @@ crds:
       - azure
     topics:
       - workloadcluster
+  machines.cluster.x-k8s.io:
+    hidden: true
+  machinesets.cluster.x-k8s.io:
+    hidden: true
   memcachedconfigs.example.giantswarm.io:
     hidden: true
   networkpools.infrastructure.giantswarm.io:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -47,7 +47,6 @@ crds:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true
   awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io:
-    awsclusterroleidentities.infrastructure.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
     hidden: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -31,6 +31,10 @@ crds:
       - https://github.com/orgs/giantswarm/teams/team-batman
     topics:
       - apps
+  awsclusters.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   awsclusters.infrastructure.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
@@ -41,11 +45,15 @@ crds:
   awsclusterconfigs.core.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
-    publish: false
+    hidden: true
+  awsclusterroleidentities.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   awsconfigs.provider.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
-    publish: false
+    hidden: true
   awscontrolplanes.infrastructure.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
@@ -60,6 +68,14 @@ crds:
       - aws
     topics:
       - workloadcluster
+  awsmachinepools.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  awsmachinetemplates.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   azureclusters.infrastructure.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
@@ -70,11 +86,11 @@ crds:
   azureclusterconfigs.core.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
-    publish: false
+    hidden: true
   azureconfigs.provider.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
-    publish: false
+    hidden: true
   azuremachinepools.exp.infrastructure.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
@@ -92,7 +108,7 @@ crds:
   azuretools.tooling.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
-    publish: false
+    hidden: true
   certconfigs.core.giantswarm.io:
     owner: TODO
     topics:
@@ -104,9 +120,9 @@ crds:
     topics:
       - apps
   chartconfigs.core.giantswarm.io:
-    publish: false
+    hidden: true
   clusters.core.giantswarm.io:
-    publish: false
+    hidden: true
   clusters.cluster.x-k8s.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
@@ -123,13 +139,13 @@ crds:
       - apps
       - managementcluster
   drainerconfigs.core.giantswarm.io:
-    publish: false
+    hidden: true
   draughtsmanconfigs.core.giantswarm.io:
-    publish: false
+    hidden: true
   etcdbackups.backup.giantswarm.io:
-    publish: false
+    hidden: true
   flannelconfigs.core.giantswarm.io:
-    publish: false
+    hidden: true
   g8scontrolplanes.infrastructure.giantswarm.io:
     owner: 
       - https://github.com/orgs/giantswarm/teams/team-firecracker
@@ -143,7 +159,15 @@ crds:
       - managementcluster
       - workloadcluster
   ingressconfigs.core.giantswarm.io:
-    publish: false
+    hidden: true
+  kubeadmconfigs.bootstrap.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
+  kubeadmcontrolplanes.controlplane.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
+    hidden: true
   kvmclusterconfigs.core.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-rocket
@@ -166,7 +190,7 @@ crds:
     topics:
       - workloadcluster
   memcachedconfigs.example.giantswarm.io:
-    publish: false
+    hidden: true
   networkpools.infrastructure.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-firecracker
@@ -180,7 +204,7 @@ crds:
     topics:
       - managementcluster
   releasecycles.release.giantswarm.io:
-    publish: false
+    hidden: true
   releases.release.giantswarm.io:
     owner: TODO
     topics:
@@ -199,14 +223,14 @@ crds:
       - workloadcluster
   storageconfigs.core.giantswarm.io:
     owner: TODO
-    publish: false
+    hidden: true
     topics:
       - managementcluster
   vsphereclusters.infrastructure.cluster.x-k8s.io:
-    publish: false
+    hidden: true
   vspheremachines.infrastructure.cluster.x-k8s.io:
-    publish: false
+    hidden: true
   vspheremachinetemplates.infrastructure.cluster.x-k8s.io:
-    publish: false
+    hidden: true
   vspherevms.infrastructure.cluster.x-k8s.io:
-    publish: false
+    hidden: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -110,7 +110,8 @@ crds:
       - https://github.com/orgs/giantswarm/teams/team-celestial
     hidden: true
   certconfigs.core.giantswarm.io:
-    owner: TODO
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-ludacris
     topics:
       - managementcluster
       - workloadcluster
@@ -154,7 +155,8 @@ crds:
     topics:
       - workloadcluster
   ignitions.core.giantswarm.io:
-    owner: TODO
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-ludacris
     topics:
       - managementcluster
       - workloadcluster
@@ -206,12 +208,14 @@ crds:
   releasecycles.release.giantswarm.io:
     hidden: true
   releases.release.giantswarm.io:
-    owner: TODO
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-ludacris
     topics:
       - managementcluster
       - workloadcluster
   silences.monitoring.giantswarm.io:
-    owner: TODO
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-biscuit
     topics:
       - managementcluster
   sparks.core.giantswarm.io:
@@ -222,7 +226,6 @@ crds:
     topics:
       - workloadcluster
   storageconfigs.core.giantswarm.io:
-    owner: TODO
     hidden: true
     topics:
       - managementcluster

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -17,59 +17,90 @@
 #
 crds:
   appcatalogs.application.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-batman
     topics:
       - apps
   appcatalogentries.application.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-batman
     topics:
       - apps
   apps.application.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-batman
     topics:
       - apps
   awsclusters.infrastructure.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
     topics:
       - workloadcluster
   awsclusterconfigs.core.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     publish: false
   awsconfigs.provider.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     publish: false
   awscontrolplanes.infrastructure.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
     topics:
       - workloadcluster
   awsmachinedeployments.infrastructure.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
     topics:
       - workloadcluster
   azureclusters.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     provider:
       - azure
     topics:
       - workloadcluster
   azureclusterconfigs.core.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     publish: false
   azureconfigs.provider.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     publish: false
   azuremachinepools.exp.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     provider:
       - azure
     topics:
       - workloadcluster
   azuremachines.infrastructure.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     provider:
       - azure
     topics:
       - workloadcluster
   azuretools.tooling.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     publish: false
   certconfigs.core.giantswarm.io:
+    owner: TODO
     topics:
       - managementcluster
       - workloadcluster
   charts.application.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-batman
     topics:
       - apps
   chartconfigs.core.giantswarm.io:
@@ -77,12 +108,17 @@ crds:
   clusters.core.giantswarm.io:
     publish: false
   clusters.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
       - azure
     topics:
       - workloadcluster
   configs.core.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-biscuit
     topics:
       - apps
       - managementcluster
@@ -95,27 +131,36 @@ crds:
   flannelconfigs.core.giantswarm.io:
     publish: false
   g8scontrolplanes.infrastructure.giantswarm.io:
+    owner: 
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
     topics:
       - workloadcluster
   ignitions.core.giantswarm.io:
+    owner: TODO
     topics:
       - managementcluster
       - workloadcluster
   ingressconfigs.core.giantswarm.io:
     publish: false
   kvmclusterconfigs.core.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-rocket
     provider:
       - kvm
     topics:
       - workloadcluster
   kvmconfigs.provider.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-rocket
     provider:
       - kvm
     topics:
       - workloadcluster
   machinepools.exp.cluster.x-k8s.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     provider:
       - azure
     topics:
@@ -123,28 +168,37 @@ crds:
   memcachedconfigs.example.giantswarm.io:
     publish: false
   networkpools.infrastructure.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-firecracker
     provider:
       - aws
     topics:
       - workloadcluster
   organizations.security.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-biscuit
     topics:
       - managementcluster
   releasecycles.release.giantswarm.io:
     publish: false
   releases.release.giantswarm.io:
+    owner: TODO
     topics:
       - managementcluster
       - workloadcluster
   silences.monitoring.giantswarm.io:
+    owner: TODO
     topics:
       - managementcluster
   sparks.core.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-celestial
     provider:
       - azure
     topics:
       - workloadcluster
   storageconfigs.core.giantswarm.io:
+    owner: TODO
     publish: false
     topics:
       - managementcluster

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -109,6 +109,11 @@ crds:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-celestial
     hidden: true
+  catalogs.application.giantswarm.io:
+    owner:
+      - https://github.com/orgs/giantswarm/teams/team-batman
+    topics:
+      - apps
   certconfigs.core.giantswarm.io:
     owner:
       - https://github.com/orgs/giantswarm/teams/team-ludacris


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18019

This PR consolidates CRD-related metadata and config in the apiextensions repository, which brings it closer to the maintenance of CRDs, and reduces the number of repositories to touch when dealing with CRDs.

## Checklist

- [ ] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
