### PR TITLE
add networkpool into helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add networkpool CR into Helm chart.
+
 ## [3.28.0] - 2021-07-27
 
 ### Added

--- a/config/crd/infrastructure.giantswarm.io_networkpools.yaml
+++ b/config/crd/infrastructure.giantswarm.io_networkpools.yaml
@@ -11,6 +11,7 @@ spec:
   group: infrastructure.giantswarm.io
   names:
     categories:
+    - aws
     - giantswarm
     - cluster-api
     kind: NetworkPool

--- a/helm/crds-aws/templates/giantswarm.yaml
+++ b/helm/crds-aws/templates/giantswarm.yaml
@@ -1028,6 +1028,88 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
+  name: networkpools.infrastructure.giantswarm.io
+spec:
+  group: infrastructure.giantswarm.io
+  names:
+    categories:
+    - aws
+    - giantswarm
+    - cluster-api
+    kind: NetworkPool
+    listKind: NetworkPoolList
+    plural: networkpools
+    singular: networkpool
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: NetworkPool is the infrastructure provider referenced in upstream CAPI Cluster CRs.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkPoolSpec is the spec part for the NetworkPool resource.
+            properties:
+              cidrBlock:
+                description: IPv4 address block in CIDR notation.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: NetworkPool is the infrastructure provider referenced in upstream CAPI Cluster CRs.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkPoolSpec is the spec part for the NetworkPool resource.
+            properties:
+              cidrBlock:
+                description: IPv4 address block in CIDR notation.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
   name: awsconfigs.provider.giantswarm.io
 spec:
   group: provider.giantswarm.io

--- a/pkg/apis/infrastructure/v1alpha3/network_pool_types.go
+++ b/pkg/apis/infrastructure/v1alpha3/network_pool_types.go
@@ -8,7 +8,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories=giantswarm;cluster-api
+// +kubebuilder:resource:categories=aws;giantswarm;cluster-api
 // +k8s:openapi-gen=true
 
 // NetworkPool is the infrastructure provider referenced in upstream CAPI Cluster


### PR DESCRIPTION
`opsctl ensure crds -i giraffe --crds networkpools.infrastructure.giantswarm.io` does not consider networkpools: 

**Skipping giraffe. CRDs [networkpools.infrastructure.giantswarm.io] not found.** 

because it [fetches all CRDs from helm directory](https://github.com/giantswarm/app/blob/d06c220fb642e086969f35865feff051a21f6a75/pkg/crd/crd.go#L209). This is currently missing.

By adding the category "aws" we can ensure this will be also included in helm directory.

## Checklist

- [ ] Consider SIG UX feedback.
- [ ] Update changelog in CHANGELOG.md.