### PR TITLE
Add required field to MD's and add cluster label to all upstream CR's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add required field `clusterName` and label `cluster.x-k8s.io/cluster-name` for `v1alpha3` CAPI CR's.
+
 ## [3.30.0] - 2021-07-29
 
 ### Added

--- a/pkg/apis/infrastructure/v1alpha3/cluster.go
+++ b/pkg/apis/infrastructure/v1alpha3/cluster.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
@@ -82,10 +83,11 @@ func newAWSClusterCR(c ClusterCRsConfig) *AWSCluster {
 				annotation.Docs: "https://docs.giantswarm.io/reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io",
 			},
 			Labels: map[string]string{
-				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
-				label.Cluster:            c.ClusterID,
-				label.Organization:       c.Owner,
-				label.ReleaseVersion:     c.ReleaseVersion,
+				label.AWSOperatorVersion:   c.ReleaseComponents["aws-operator"],
+				label.Cluster:              c.ClusterID,
+				label.Organization:         c.Owner,
+				label.ReleaseVersion:       c.ReleaseVersion,
+				clusterv1.ClusterLabelName: c.ClusterID,
 			},
 		},
 		Spec: AWSClusterSpec{

--- a/pkg/apis/infrastructure/v1alpha3/nodepool.go
+++ b/pkg/apis/infrastructure/v1alpha3/nodepool.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
@@ -123,11 +124,14 @@ func newMachineDeploymentCR(obj *AWSMachineDeployment, c NodePoolCRsConfig) *api
 				label.MachineDeployment:      c.MachineDeploymentID,
 				label.Organization:           c.Owner,
 				label.ReleaseVersion:         c.ReleaseVersion,
+				clusterv1.ClusterLabelName:   c.ClusterID,
 			},
 		},
 		Spec: apiv1alpha3.MachineDeploymentSpec{
+			ClusterName: c.ClusterID,
 			Template: apiv1alpha3.MachineTemplateSpec{
 				Spec: apiv1alpha3.MachineSpec{
+					ClusterName: c.ClusterID,
 					InfrastructureRef: corev1.ObjectReference{
 						APIVersion: obj.TypeMeta.APIVersion,
 						Kind:       obj.TypeMeta.Kind,


### PR DESCRIPTION
When creating `v1alpha3` CR's directly, we need to include `clusterName` because it is a required field for `Machinedeployment`. We also want to add the upstream cluster label on all upstream CR's. 

New label which will be added when creating `v1alpha3` CR's directly:

`cluster.x-k8s.io/cluster-name: my-cluster`

Mandatory fields:

https://github.com/kubernetes-sigs/cluster-api/blob/dfeb8d447bdcc0206b7669df20f0e2f99c15d47a/api/v1alpha2/machinedeployment_types.go#L48-L51

https://github.com/kubernetes-sigs/cluster-api/blob/39f47041a7897b378956a8f7b69fe5ed4d8ab017/api/v1alpha3/machine_types.go#L57-L60

## Checklist

- [ ] Consider SIG UX feedback.
- [ ] Update changelog in CHANGELOG.md.