### PR TITLE
Add support for new silence matcher types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for new matcher types in `silence.monitoring.giantswarm.io/v1alpha1` CRD
+
 ## [3.31.0] - 2021-08-06
 
 ### Added

--- a/config/crd/monitoring.giantswarm.io_silences.yaml
+++ b/config/crd/monitoring.giantswarm.io_silences.yaml
@@ -42,6 +42,8 @@ spec:
               matchers:
                 items:
                   properties:
+                    isEqual:
+                      type: boolean
                     isRegex:
                       type: boolean
                     name:

--- a/helm/crds-common/templates/giantswarm.yaml
+++ b/helm/crds-common/templates/giantswarm.yaml
@@ -2078,6 +2078,8 @@ spec:
               matchers:
                 items:
                   properties:
+                    isEqual:
+                      type: boolean
                     isRegex:
                       type: boolean
                     name:

--- a/pkg/apis/monitoring/v1alpha1/silence_types.go
+++ b/pkg/apis/monitoring/v1alpha1/silence_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
@@ -57,8 +59,23 @@ type TargetTag struct {
 
 type Matcher struct {
 	IsRegex bool   `json:"isRegex"`
+	IsEqual bool   `json:"isEqual,omitempty"`
 	Name    string `json:"name"`
 	Value   string `json:"value"`
+}
+
+func (m *Matcher) UnmarshalJSON(text []byte) error {
+	type innerMatcher Matcher
+
+	// We check for equality by default to keep the API
+	matcher := &innerMatcher{
+		IsEqual: true,
+	}
+	if err := json.Unmarshal(text, matcher); err != nil {
+		return err
+	}
+	*m = Matcher(*matcher)
+	return nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
We can actually keep the existing silence CRD by adding a new value set to true by default

## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
