### PR TITLE
Add example CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add example CRs for `clusters.v1alpha3.cluster.x-k8s.io`, `machinepools.v1alpha3.exp.cluster.x-k8s.io`, `machinepools.v1alpha3.cluster.x-k8s.io` and `azuremachinepools.v1alpha3.infrastructure.cluster.x-k8s.io`.
+
 ### Changed
 
 - Updated URLs to CRD docs and release notes

--- a/docs/cr/cluster.x-k8s.io_v1alpha3_cluster.yaml
+++ b/docs/cr/cluster.x-k8s.io_v1alpha3_cluster.yaml
@@ -1,0 +1,39 @@
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: Cluster
+metadata:
+  annotations:
+    cluster.giantswarm.io/description: production
+    release.giantswarm.io/last-deployed-version: 15.1.1
+  labels:
+    azure-operator.giantswarm.io/version: 5.8.1
+    cluster-operator.giantswarm.io/version: 0.27.1
+    cluster.x-k8s.io/cluster-name: x4j3p
+    giantswarm.io/cluster: x4j3p
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 15.1.1
+  name: x4j3p
+  namespace: org-giantswarm
+spec:
+  clusterNetwork:
+    apiServerPort: 443
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 172.31.0.0/16
+  controlPlaneEndpoint:
+    host: api.example.com
+    port: 443
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AzureMachine
+    name: x4j3p-master-0
+    namespace: org-giantswarm
+    resourceVersion: "374040211"
+    uid: 177991ca-5de0-48f6-a956-47abcb218a3b
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AzureCluster
+    name: x4j3p
+    namespace: org-giantswarm
+    resourceVersion: "374040188"
+    uid: 01d6767e-c394-43a7-bf17-2eaf11e80dcb

--- a/docs/cr/cluster.x-k8s.io_v1alpha3_machinepool.yaml
+++ b/docs/cr/cluster.x-k8s.io_v1alpha3_machinepool.yaml
@@ -1,0 +1,47 @@
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  annotations:
+    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "10"
+    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
+    machine-pool.giantswarm.io/name: Unnamed node pool
+    release.giantswarm.io/last-deployed-version: 15.1.1
+  labels:
+    azure-operator.giantswarm.io/version: 5.8.1
+    cluster-operator.giantswarm.io/version: 0.27.1
+    cluster.x-k8s.io/cluster-name: x4j3p
+    giantswarm.io/cluster: x4j3p
+    giantswarm.io/machine-pool: q5k7t
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 15.1.1
+  name: q5k7t
+  namespace: org-giantswarm
+spec:
+  clusterName: x4j3p
+  failureDomains:
+    - "2"
+  minReadySeconds: 0
+  providerIDList:
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/0
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/1
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/2
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: core.giantswarm.io/v1alpha1
+          kind: Spark
+          name: q5k7t
+          namespace: org-giantswarm
+          resourceVersion: "374040263"
+          uid: a4f5af79-1354-4c99-a68b-433deaff2ede
+      clusterName: x4j3p
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: q5k7t
+        namespace: org-giantswarm
+        resourceVersion: "374040262"
+        uid: 4d1e7420-53a8-4a38-8a2c-0bd30f93a593

--- a/docs/cr/exp.cluster.x-k8s.io_v1alpha3_machinepool.yaml
+++ b/docs/cr/exp.cluster.x-k8s.io_v1alpha3_machinepool.yaml
@@ -1,0 +1,47 @@
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  annotations:
+    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "10"
+    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
+    machine-pool.giantswarm.io/name: Unnamed node pool
+    release.giantswarm.io/last-deployed-version: 15.1.1
+  labels:
+    azure-operator.giantswarm.io/version: 5.8.1
+    cluster-operator.giantswarm.io/version: 0.27.1
+    cluster.x-k8s.io/cluster-name: x4j3p
+    giantswarm.io/cluster: x4j3p
+    giantswarm.io/machine-pool: q5k7t
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 15.1.1
+  name: q5k7t
+  namespace: org-giantswarm
+spec:
+  clusterName: x4j3p
+  failureDomains:
+  - "2"
+  minReadySeconds: 0
+  providerIDList:
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/0
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/1
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/2
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: core.giantswarm.io/v1alpha1
+          kind: Spark
+          name: q5k7t
+          namespace: org-giantswarm
+          resourceVersion: "374040263"
+          uid: a4f5af79-1354-4c99-a68b-433deaff2ede
+      clusterName: x4j3p
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: q5k7t
+        namespace: org-giantswarm
+        resourceVersion: "374040262"
+        uid: 4d1e7420-53a8-4a38-8a2c-0bd30f93a593

--- a/docs/cr/infrastructure.cluster.x-k8s.io_v1alpha3_azuremachinepool.yaml
+++ b/docs/cr/infrastructure.cluster.x-k8s.io_v1alpha3_azuremachinepool.yaml
@@ -1,0 +1,35 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureMachinePool
+metadata:
+  labels:
+    azure-operator.giantswarm.io/version: 5.3.1
+    cluster.x-k8s.io/cluster-name: mmh5x
+    giantswarm.io/cluster: mmh5x
+    giantswarm.io/machine-pool: w86vu
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 14.1.0
+  name: w86vu
+  namespace: org-giantswarm
+spec:
+  identity: None
+  location: westeurope
+  providerID: azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu
+  providerIDList:
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/0
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/1
+    - azure:///subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/mmh5x/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-w86vu/virtualMachines/2
+  template:
+    dataDisks:
+      - diskSizeGB: 100
+        lun: 21
+        nameSuffix: docker
+      - diskSizeGB: 100
+        lun: 22
+        nameSuffix: kubelet
+    osDisk:
+      diskSizeGB: 0
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: ""
+    sshPublicKey: ""
+    vmSize: Standard_D4s_v3


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15025

I'm adding two `MachinePools` and two `AzureMachinePools` but they belong to two different api groups. The ones with `exp` in the name will be removed eventually, as they got removed upstream.

## Checklist

- [ ] Consider SIG UX feedback.
- [X] Update changelog in CHANGELOG.md.
