### PR TITLE
Use capz v0.4.x on Azure CRDs so that we have the experimental CRDs on their old api group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use capz `v0.4.x` on Azure CRDs so that we have the experimental CRDs on their old api group.
+
 ## [3.34.0] - 2021-10-13
 
 ### Fixed

--- a/hack/assets.go
+++ b/hack/assets.go
@@ -35,7 +35,7 @@ var upstreamReleaseAssets = []crd.ReleaseAssetFileDefinition{
 	{
 		Owner:    "kubernetes-sigs",
 		Repo:     "cluster-api-provider-azure",
-		Version:  "v0.5.3",
+		Version:  "v0.4.15",
 		Files:    []string{"infrastructure-components.yaml"},
 		Provider: "azure",
 	},

--- a/helm/crds-azure/templates/upstream.yaml
+++ b/helm/crds-azure/templates/upstream.yaml
@@ -6337,11 +6337,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1alpha3: v1alpha3
   name: azureclusteridentities.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -6357,7 +6357,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureClusterIdentity is the Schema for the azureclustersidentities API.
+        description: AzureClusterIdentity is the Schema for the azureclustersidentities API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -6368,7 +6368,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
+            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity
             properties:
               allowedNamespaces:
                 description: "AllowedNamespaces is an array of namespaces that AzureClusters can use this Identity from. \n An empty list (default) indicates that AzureClusters can use this Identity from any namespace. This field is intentionally not a pointer because the nil behavior (no namespaces) is undesirable here."
@@ -6406,132 +6406,7 @@ spec:
             - type
             type: object
           status:
-            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
-            properties:
-              conditions:
-                description: Conditions defines current service state of the AzureClusterIdentity.
-                items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                      type: string
-                    severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureClusterIdentity is the Schema for the azureclustersidentities API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
-            properties:
-              allowedNamespaces:
-                description: AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AzureClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.
-                nullable: true
-                properties:
-                  list:
-                    description: A nil or empty list indicates that AzureCluster cannot use the identity from any namespace.
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  selector:
-                    description: "Selector is a selector of namespaces that AzureCluster can use this Identity from. This is a standard Kubernetes LabelSelector, a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. \n A nil or empty selector indicates that AzureCluster cannot use this AzureClusterIdentity from any namespace."
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                type: object
-              clientID:
-                description: Both User Assigned MSI and SP can use this field.
-                type: string
-              clientSecret:
-                description: ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.
-                properties:
-                  name:
-                    description: Name is unique within a namespace to reference a secret resource.
-                    type: string
-                  namespace:
-                    description: Namespace defines the space within which the secret name must be unique.
-                    type: string
-                type: object
-              resourceID:
-                description: User assigned MSI resource id.
-                type: string
-              tenantID:
-                description: Service principal primary tenant id.
-                type: string
-              type:
-                description: UserAssignedMSI or Service Principal
-                enum:
-                - ServicePrincipal
-                - UserAssignedMSI
-                type: string
-            required:
-            - clientID
-            - tenantID
-            - type
-            type: object
-          status:
-            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
+            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureClusterIdentity.
@@ -6580,11 +6455,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1alpha3: v1alpha3
   name: azureclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -6597,6 +6472,321 @@ spec:
     singular: azurecluster
   scope: Namespaced
   versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AzureCluster is the Schema for the azureclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureClusterSpec defines the desired state of AzureCluster
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.
+                type: object
+              location:
+                type: string
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to Azure network.
+                properties:
+                  subnets:
+                    description: Subnets is the configuration for the control-plane subnet and the node subnet.
+                    items:
+                      description: SubnetSpec configures an Azure subnet.
+                      properties:
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when the provider creates a managed Vnet.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference this resource.
+                          type: string
+                        internalLBIPAddress:
+                          description: InternalLBIPAddress is the IP address that will be used as the internal LB private IP. For the control plane subnet only.
+                          type: string
+                        name:
+                          description: Name defines a name for the subnet resource.
+                          type: string
+                        role:
+                          description: Role defines the subnet role (eg. Node, ControlPlane)
+                          type: string
+                        securityGroup:
+                          description: SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
+                          properties:
+                            id:
+                              type: string
+                            ingressRule:
+                              description: IngressRules is a slice of Azure ingress rules for security groups.
+                              items:
+                                description: IngressRule defines an Azure ingress rule for security groups.
+                                properties:
+                                  description:
+                                    type: string
+                                  destination:
+                                    description: Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                                    type: string
+                                  destinationPorts:
+                                    description: DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                    type: string
+                                  protocol:
+                                    description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                                    type: string
+                                  source:
+                                    description: Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
+                                    type: string
+                                  sourcePorts:
+                                    description: SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                    type: string
+                                required:
+                                - description
+                                - protocol
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags defines a map of tags.
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  vnet:
+                    description: Vnet is the configuration for the Azure virtual network.
+                    properties:
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the provider creates a managed virtual network.
+                        type: string
+                      id:
+                        description: ID is the identifier of the virtual network this provider should use to create resources.
+                        type: string
+                      name:
+                        description: Name defines a name for the virtual network resource.
+                        type: string
+                      resourceGroup:
+                        description: ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    required:
+                    - name
+                    type: object
+                type: object
+              resourceGroup:
+                type: string
+            required:
+            - location
+            - resourceGroup
+            type: object
+          status:
+            description: AzureClusterStatus defines the observed state of AzureCluster
+            properties:
+              apiEndpoints:
+                description: APIEndpoints represents the endpoints to communicate with the control plane.
+                items:
+                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                  properties:
+                    host:
+                      description: The hostname on which the API server is serving.
+                      type: string
+                    port:
+                      description: The port on which the API server is serving.
+                      type: integer
+                  required:
+                  - host
+                  - port
+                  type: object
+                type: array
+              bastion:
+                description: VM describes an Azure virtual machine.
+                properties:
+                  addresses:
+                    description: Addresses contains the Azure instance associated addresses.
+                    items:
+                      description: NodeAddress contains information for the node's address.
+                      properties:
+                        address:
+                          description: The node address.
+                          type: string
+                        type:
+                          description: Node address type, one of Hostname, ExternalIP or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    type: string
+                  id:
+                    type: string
+                  identity:
+                    description: VMIdentity defines the identity of the virtual machine, if configured.
+                    type: string
+                  image:
+                    description: Storage profile
+                    properties:
+                      gallery:
+                        type: string
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      offer:
+                        type: string
+                      publisher:
+                        type: string
+                      resourceGroup:
+                        type: string
+                      sku:
+                        type: string
+                      subscriptionID:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  name:
+                    type: string
+                  osDisk:
+                    properties:
+                      diskSizeGB:
+                        format: int32
+                        type: integer
+                      managedDisk:
+                        properties:
+                          storageAccountType:
+                            type: string
+                        required:
+                        - storageAccountType
+                        type: object
+                      osType:
+                        type: string
+                    required:
+                    - diskSizeGB
+                    - managedDisk
+                    - osType
+                    type: object
+                  startupScript:
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: Tags defines a map of tags.
+                    type: object
+                  vmSize:
+                    description: Hardware profile
+                    type: string
+                  vmState:
+                    description: State - The provisioning state, which only appears in the response.
+                    type: string
+                type: object
+              network:
+                description: Network encapsulates Azure networking resources.
+                properties:
+                  apiServerIp:
+                    description: APIServerIP is the Kubernetes API server public IP address.
+                    properties:
+                      dnsName:
+                        type: string
+                      id:
+                        type: string
+                      ipAddress:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  apiServerLb:
+                    description: APIServerLB is the Kubernetes API server load balancer.
+                    properties:
+                      backendPool:
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      frontendIpConfig:
+                        type: object
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      sku:
+                        description: LoadBalancerSKU enumerates the values for load balancer sku name.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags defines a map of tags.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an Azure security group.
+                      properties:
+                        id:
+                          type: string
+                        ingressRule:
+                          description: IngressRules is a slice of Azure ingress rules for security groups.
+                          items:
+                            description: IngressRule defines an Azure ingress rule for security groups.
+                            properties:
+                              description:
+                                type: string
+                              destination:
+                                description: Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                                type: string
+                              destinationPorts:
+                                description: DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                type: string
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                                type: string
+                              source:
+                                description: Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
+                                type: string
+                              sourcePorts:
+                                description: SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                type: string
+                            required:
+                            - description
+                            - protocol
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags defines a map of tags.
+                          type: object
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
   - additionalPrinterColumns:
     - description: Cluster to which this AzureCluster belongs
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
@@ -6625,7 +6815,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureCluster is the Schema for the azureclusters API.
+        description: AzureCluster is the Schema for the azureclusters API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -6636,7 +6826,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterSpec defines the desired state of AzureCluster.
+            description: AzureClusterSpec defines the desired state of AzureCluster
             properties:
               additionalTags:
                 additionalProperties:
@@ -6845,7 +7035,7 @@ spec:
             - location
             type: object
           status:
-            description: AzureClusterStatus defines the observed state of AzureCluster.
+            description: AzureClusterStatus defines the observed state of AzureCluster
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureCluster.
@@ -6897,669 +7087,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: Cluster to which this AzureCluster belongs
-      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
-      name: Cluster
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].message
-      name: Message
-      priority: 1
-      type: string
-    - jsonPath: .spec.resourceGroup
-      name: Resource Group
-      priority: 1
-      type: string
-    - jsonPath: .spec.subscriptionID
-      name: SubscriptionID
-      priority: 1
-      type: string
-    - jsonPath: .spec.location
-      name: Location
-      priority: 1
-      type: string
-    - description: Control Plane Endpoint
-      jsonPath: .spec.controlPlaneEndpoint.host
-      name: Endpoint
-      priority: 1
-      type: string
-    name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureCluster is the Schema for the azureclusters API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureClusterSpec defines the desired state of AzureCluster.
-            properties:
-              additionalTags:
-                additionalProperties:
-                  type: string
-                description: AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.
-                type: object
-              azureEnvironment:
-                description: 'AzureEnvironment is the name of the AzureCloud to be used. The default value that would be used by most users is "AzurePublicCloud", other values are: - ChinaCloud: "AzureChinaCloud" - GermanCloud: "AzureGermanCloud" - PublicCloud: "AzurePublicCloud" - USGovernmentCloud: "AzureUSGovernmentCloud"'
-                type: string
-              bastionSpec:
-                description: BastionSpec encapsulates all things related to the Bastions in the cluster.
-                properties:
-                  azureBastion:
-                    description: AzureBastion specifies how the Azure Bastion cloud component should be configured.
-                    properties:
-                      name:
-                        type: string
-                      publicIP:
-                        description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                        properties:
-                          dnsName:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      subnet:
-                        description: SubnetSpec configures an Azure subnet.
-                        properties:
-                          cidrBlocks:
-                            description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
-                            items:
-                              type: string
-                            type: array
-                          id:
-                            description: ID defines a unique identifier to reference this resource.
-                            type: string
-                          name:
-                            description: Name defines a name for the subnet resource.
-                            type: string
-                          natGateway:
-                            description: NatGateway associated with this subnet.
-                            properties:
-                              id:
-                                type: string
-                              ip:
-                                description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                                properties:
-                                  dnsName:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              name:
-                                type: string
-                            type: object
-                          role:
-                            description: Role defines the subnet role (eg. Node, ControlPlane)
-                            type: string
-                          routeTable:
-                            description: RouteTable defines the route table that should be attached to this subnet.
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                            type: object
-                          securityGroup:
-                            description: SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                              securityRules:
-                                description: SecurityRules is a slice of Azure security rules for security groups.
-                                items:
-                                  description: SecurityRule defines an Azure security rule for security groups.
-                                  properties:
-                                    description:
-                                      description: A description for this rule. Restricted to 140 chars.
-                                      type: string
-                                    destination:
-                                      description: Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
-                                      type: string
-                                    destinationPorts:
-                                      description: DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
-                                      type: string
-                                    direction:
-                                      description: Direction indicates whether the rule applies to inbound, or outbound traffic. "Inbound" or "Outbound".
-                                      enum:
-                                      - Inbound
-                                      - Outbound
-                                      type: string
-                                    name:
-                                      description: Name is a unique name within the network security group.
-                                      type: string
-                                    priority:
-                                      description: Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.
-                                      format: int32
-                                      type: integer
-                                    protocol:
-                                      description: Protocol specifies the protocol type. "Tcp", "Udp", "Icmp", or "*".
-                                      enum:
-                                      - Tcp
-                                      - Udp
-                                      - Icmp
-                                      - '*'
-                                      type: string
-                                    source:
-                                      description: Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
-                                      type: string
-                                    sourcePorts:
-                                      description: SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
-                                      type: string
-                                  required:
-                                  - description
-                                  - direction
-                                  - name
-                                  - protocol
-                                  type: object
-                                type: array
-                              tags:
-                                additionalProperties:
-                                  type: string
-                                description: Tags defines a map of tags.
-                                type: object
-                            type: object
-                        required:
-                        - name
-                        type: object
-                    type: object
-                type: object
-              cloudProviderConfigOverrides:
-                description: 'CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config. This is only a subset of options that are available in azure cloud provider config. Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.'
-                properties:
-                  backOffs:
-                    description: BackOffConfig indicates the back-off config options.
-                    properties:
-                      cloudProviderBackoff:
-                        type: boolean
-                      cloudProviderBackoffDuration:
-                        type: integer
-                      cloudProviderBackoffExponent:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      cloudProviderBackoffJitter:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      cloudProviderBackoffRetries:
-                        type: integer
-                    type: object
-                  rateLimits:
-                    items:
-                      description: 'RateLimitSpec represents the rate limit configuration for a particular kind of resource. Eg. loadBalancerRateLimit is used to configure rate limits for load balancers. This eventually gets converted to CloudProviderRateLimitConfig that cloud-provider-azure expects. See: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25 We cannot use CloudProviderRateLimitConfig directly because floating point values are not supported in controller-tools. See: https://github.com/kubernetes-sigs/controller-tools/issues/245'
-                      properties:
-                        config:
-                          description: RateLimitConfig indicates the rate limit config options.
-                          properties:
-                            cloudProviderRateLimit:
-                              type: boolean
-                            cloudProviderRateLimitBucket:
-                              type: integer
-                            cloudProviderRateLimitBucketWrite:
-                              type: integer
-                            cloudProviderRateLimitQPS:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            cloudProviderRateLimitQPSWrite:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        name:
-                          description: Name is the name of the rate limit spec.
-                          enum:
-                          - defaultRateLimit
-                          - routeRateLimit
-                          - subnetsRateLimit
-                          - interfaceRateLimit
-                          - routeTableRateLimit
-                          - loadBalancerRateLimit
-                          - publicIPAddressRateLimit
-                          - securityGroupRateLimit
-                          - virtualMachineRateLimit
-                          - storageAccountRateLimit
-                          - diskRateLimit
-                          - snapshotRateLimit
-                          - virtualMachineScaleSetRateLimit
-                          - virtualMachineSizesRateLimit
-                          - availabilitySetRateLimit
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    format: int32
-                    type: integer
-                required:
-                - host
-                - port
-                type: object
-              identityRef:
-                description: IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              location:
-                type: string
-              networkSpec:
-                description: NetworkSpec encapsulates all things related to Azure network.
-                properties:
-                  apiServerLB:
-                    description: APIServerLB is the configuration for the control-plane load balancer.
-                    properties:
-                      frontendIPs:
-                        items:
-                          description: FrontendIP defines a load balancer frontend IP configuration.
-                          properties:
-                            name:
-                              minLength: 1
-                              type: string
-                            privateIP:
-                              type: string
-                            publicIP:
-                              description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                              properties:
-                                dnsName:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      frontendIPsCount:
-                        description: FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.
-                        format: int32
-                        type: integer
-                      id:
-                        type: string
-                      idleTimeoutInMinutes:
-                        description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
-                        format: int32
-                        type: integer
-                      name:
-                        type: string
-                      sku:
-                        description: SKU defines an Azure load balancer SKU.
-                        type: string
-                      type:
-                        description: LBType defines an Azure load balancer Type.
-                        type: string
-                    type: object
-                  controlPlaneOutboundLB:
-                    description: ControlPlaneOutboundLB is the configuration for the control-plane outbound load balancer. This is different from APIServerLB, and is used only in private clusters (optionally) for enabling outbound traffic.
-                    properties:
-                      frontendIPs:
-                        items:
-                          description: FrontendIP defines a load balancer frontend IP configuration.
-                          properties:
-                            name:
-                              minLength: 1
-                              type: string
-                            privateIP:
-                              type: string
-                            publicIP:
-                              description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                              properties:
-                                dnsName:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      frontendIPsCount:
-                        description: FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.
-                        format: int32
-                        type: integer
-                      id:
-                        type: string
-                      idleTimeoutInMinutes:
-                        description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
-                        format: int32
-                        type: integer
-                      name:
-                        type: string
-                      sku:
-                        description: SKU defines an Azure load balancer SKU.
-                        type: string
-                      type:
-                        description: LBType defines an Azure load balancer Type.
-                        type: string
-                    type: object
-                  nodeOutboundLB:
-                    description: NodeOutboundLB is the configuration for the node outbound load balancer.
-                    properties:
-                      frontendIPs:
-                        items:
-                          description: FrontendIP defines a load balancer frontend IP configuration.
-                          properties:
-                            name:
-                              minLength: 1
-                              type: string
-                            privateIP:
-                              type: string
-                            publicIP:
-                              description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                              properties:
-                                dnsName:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      frontendIPsCount:
-                        description: FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.
-                        format: int32
-                        type: integer
-                      id:
-                        type: string
-                      idleTimeoutInMinutes:
-                        description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
-                        format: int32
-                        type: integer
-                      name:
-                        type: string
-                      sku:
-                        description: SKU defines an Azure load balancer SKU.
-                        type: string
-                      type:
-                        description: LBType defines an Azure load balancer Type.
-                        type: string
-                    type: object
-                  privateDNSZoneName:
-                    description: PrivateDNSZoneName defines the zone name for the Azure Private DNS.
-                    type: string
-                  subnets:
-                    description: Subnets is the configuration for the control-plane subnet and the node subnet.
-                    items:
-                      description: SubnetSpec configures an Azure subnet.
-                      properties:
-                        cidrBlocks:
-                          description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
-                          items:
-                            type: string
-                          type: array
-                        id:
-                          description: ID defines a unique identifier to reference this resource.
-                          type: string
-                        name:
-                          description: Name defines a name for the subnet resource.
-                          type: string
-                        natGateway:
-                          description: NatGateway associated with this subnet.
-                          properties:
-                            id:
-                              type: string
-                            ip:
-                              description: PublicIPSpec defines the inputs to create an Azure public IP address.
-                              properties:
-                                dnsName:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            name:
-                              type: string
-                          type: object
-                        role:
-                          description: Role defines the subnet role (eg. Node, ControlPlane)
-                          type: string
-                        routeTable:
-                          description: RouteTable defines the route table that should be attached to this subnet.
-                          properties:
-                            id:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        securityGroup:
-                          description: SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
-                          properties:
-                            id:
-                              type: string
-                            name:
-                              type: string
-                            securityRules:
-                              description: SecurityRules is a slice of Azure security rules for security groups.
-                              items:
-                                description: SecurityRule defines an Azure security rule for security groups.
-                                properties:
-                                  description:
-                                    description: A description for this rule. Restricted to 140 chars.
-                                    type: string
-                                  destination:
-                                    description: Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
-                                    type: string
-                                  destinationPorts:
-                                    description: DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
-                                    type: string
-                                  direction:
-                                    description: Direction indicates whether the rule applies to inbound, or outbound traffic. "Inbound" or "Outbound".
-                                    enum:
-                                    - Inbound
-                                    - Outbound
-                                    type: string
-                                  name:
-                                    description: Name is a unique name within the network security group.
-                                    type: string
-                                  priority:
-                                    description: Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.
-                                    format: int32
-                                    type: integer
-                                  protocol:
-                                    description: Protocol specifies the protocol type. "Tcp", "Udp", "Icmp", or "*".
-                                    enum:
-                                    - Tcp
-                                    - Udp
-                                    - Icmp
-                                    - '*'
-                                    type: string
-                                  source:
-                                    description: Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
-                                    type: string
-                                  sourcePorts:
-                                    description: SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
-                                    type: string
-                                required:
-                                - description
-                                - direction
-                                - name
-                                - protocol
-                                type: object
-                              type: array
-                            tags:
-                              additionalProperties:
-                                type: string
-                              description: Tags defines a map of tags.
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  vnet:
-                    description: Vnet is the configuration for the Azure virtual network.
-                    properties:
-                      cidrBlocks:
-                        description: CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.
-                        items:
-                          type: string
-                        type: array
-                      id:
-                        description: ID is the identifier of the virtual network this provider should use to create resources.
-                        type: string
-                      name:
-                        description: Name defines a name for the virtual network resource.
-                        type: string
-                      resourceGroup:
-                        description: ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.
-                        type: string
-                      tags:
-                        additionalProperties:
-                          type: string
-                        description: Tags is a collection of tags describing the resource.
-                        type: object
-                    required:
-                    - name
-                    type: object
-                type: object
-              resourceGroup:
-                type: string
-              subscriptionID:
-                type: string
-            required:
-            - location
-            type: object
-          status:
-            description: AzureClusterStatus defines the observed state of AzureCluster.
-            properties:
-              conditions:
-                description: Conditions defines current service state of the AzureCluster.
-                items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                      type: string
-                    severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              failureDomains:
-                additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
-                  properties:
-                    attributes:
-                      additionalProperties:
-                        type: string
-                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
-                      type: object
-                    controlPlane:
-                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
-                      type: boolean
-                  type: object
-                description: 'FailureDomains specifies the list of unique failure domains for the location/region of the cluster. A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An Availability Zone is a separate data center within a region and they can be used to ensure the cluster is more resilient to failure. See: https://docs.microsoft.com/en-us/azure/availability-zones/az-overview This list will be used by Cluster API to try and spread the machines across the failure domains.'
-                type: object
-              longRunningOperationStates:
-                description: LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.
-                items:
-                  description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
-                  properties:
-                    data:
-                      description: Data is the base64 url encoded json Azure AutoRest Future.
-                      type: string
-                    name:
-                      description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
-                      type: string
-                    resourceGroup:
-                      description: ResourceGroup is the Azure resource group for the resource.
-                      type: string
-                    serviceName:
-                      description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
-                      type: string
-                    type:
-                      description: Type describes the type of future, such as update, create, delete, etc.
-                      type: string
-                  required:
-                  - name
-                  - serviceName
-                  - type
-                  type: object
-                type: array
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-            type: object
-        type: object
-    served: true
     storage: true
     subresources:
       status: {}
@@ -7575,366 +7102,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-  name: azureidentities.aadpodidentity.k8s.io
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: azuremachinepools.exp.infrastructure.cluster.x-k8s.io
 spec:
-  group: aadpodidentity.k8s.io
-  names:
-    kind: AzureIdentity
-    listKind: AzureIdentityList
-    plural: azureidentities
-    singular: azureidentity
-  scope: Namespaced
-  versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: AzureIdentity is the specification of the identity data structure.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureIdentitySpec describes the credential specifications of an identity on Azure.
-            properties:
-              adEndpoint:
-                type: string
-              adResourceID:
-                description: For service principal. Option param for specifying the  AD details.
-                type: string
-              auxiliaryTenantIDs:
-                description: Service principal auxiliary tenant ids
-                items:
-                  type: string
-                nullable: true
-                type: array
-              clientID:
-                description: Both User Assigned MSI and SP can use this field.
-                type: string
-              clientPassword:
-                description: Used for service principal
-                properties:
-                  name:
-                    description: Name is unique within a namespace to reference a secret resource.
-                    type: string
-                  namespace:
-                    description: Namespace defines the space within which the secret name must be unique.
-                    type: string
-                type: object
-              metadata:
-                type: object
-              replicas:
-                format: int32
-                nullable: true
-                type: integer
-              resourceID:
-                description: User assigned MSI resource id.
-                type: string
-              tenantID:
-                description: Service principal primary tenant id.
-                type: string
-              type:
-                description: UserAssignedMSI or Service Principal
-                type: integer
-            type: object
-          status:
-            description: AzureIdentityStatus contains the replica status of the resource.
-            properties:
-              availableReplicas:
-                format: int32
-                type: integer
-              metadata:
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    api-approved.kubernetes.io: unapproved
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-azure
-  name: azureidentitybindings.aadpodidentity.k8s.io
-spec:
-  group: aadpodidentity.k8s.io
-  names:
-    kind: AzureIdentityBinding
-    listKind: AzureIdentityBindingList
-    plural: azureidentitybindings
-    singular: azureidentitybinding
-  scope: Namespaced
-  versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: AzureIdentityBinding brings together the spec of matching pods and the identity which they can use.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureIdentityBindingSpec matches the pod with the Identity. Used to indicate the potential matches to look for between the pod/deployment and the identities present.
-            properties:
-              azureIdentity:
-                type: string
-              metadata:
-                type: object
-              selector:
-                type: string
-              weight:
-                description: Weight is used to figure out which of the matching identities would be selected.
-                type: integer
-            type: object
-          status:
-            description: AzureIdentityBindingStatus contains the status of an AzureIdentityBinding.
-            properties:
-              availableReplicas:
-                format: int32
-                type: integer
-              metadata:
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
-  name: azuremachinepoolmachines.infrastructure.cluster.x-k8s.io
-spec:
-  group: infrastructure.cluster.x-k8s.io
-  names:
-    categories:
-    - cluster-api
-    kind: AzureMachinePoolMachine
-    listKind: AzureMachinePoolMachineList
-    plural: azuremachinepoolmachines
-    shortNames:
-    - ampm
-    singular: azuremachinepoolmachine
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Kubernetes version
-      jsonPath: .status.version
-      name: Version
-      type: string
-    - description: Flag indicating infrastructure is successfully provisioned
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: Azure VMSS VM provisioning state
-      jsonPath: .status.provisioningState
-      name: State
-      type: string
-    - description: Cluster to which this AzureMachinePoolMachine belongs
-      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
-      name: Cluster
-      priority: 1
-      type: string
-    - description: Azure VMSS VM ID
-      jsonPath: .spec.providerID
-      name: VMSS VM ID
-      priority: 1
-      type: string
-    name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine.
-            properties:
-              instanceID:
-                description: InstanceID is the identification of the Machine Instance within the VMSS
-                type: string
-              providerID:
-                description: ProviderID is the identification ID of the Virtual Machine Scale Set
-                type: string
-            required:
-            - instanceID
-            - providerID
-            type: object
-          status:
-            description: AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine.
-            properties:
-              conditions:
-                description: Conditions defines current service state of the AzureMachinePool.
-                items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                      type: string
-                    severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              failureMessage:
-                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output."
-                type: string
-              failureReason:
-                description: "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool machine and will contain a succinct value suitable for machine interpretation. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output."
-                type: string
-              instanceName:
-                description: InstanceName is the name of the Machine Instance within the VMSS
-                type: string
-              latestModelApplied:
-                description: LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.
-                type: boolean
-              longRunningOperationStates:
-                description: LongRunningOperationStates saves the state for Azure long running operations so they can be continued on the next reconciliation loop.
-                items:
-                  description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
-                  properties:
-                    data:
-                      description: Data is the base64 url encoded json Azure AutoRest Future.
-                      type: string
-                    name:
-                      description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
-                      type: string
-                    resourceGroup:
-                      description: ResourceGroup is the Azure resource group for the resource.
-                      type: string
-                    serviceName:
-                      description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
-                      type: string
-                    type:
-                      description: Type describes the type of future, such as update, create, delete, etc.
-                      type: string
-                  required:
-                  - name
-                  - serviceName
-                  - type
-                  type: object
-                type: array
-              nodeRef:
-                description: NodeRef will point to the corresponding Node if it exists.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              provisioningState:
-                description: ProvisioningState is the provisioning state of the Azure virtual machine instance.
-                type: string
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-              version:
-                description: Version defines the Kubernetes version for the VM Instance
-                type: string
-            required:
-            - latestModelApplied
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
-  name: azuremachinepools.infrastructure.cluster.x-k8s.io
-spec:
-  group: infrastructure.cluster.x-k8s.io
+  group: exp.infrastructure.cluster.x-k8s.io
   names:
     categories:
     - cluster-api
@@ -7982,7 +7157,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureMachinePool is the Schema for the azuremachinepools API.
+        description: AzureMachinePool is the Schema for the azuremachinepools API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -7993,7 +7168,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool.
+            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool
             properties:
               additionalTags:
                 additionalProperties:
@@ -8023,7 +7198,7 @@ spec:
                 description: RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.
                 type: string
               template:
-                description: Template contains the details used to build a replica virtual machine within the Machine Pool.
+                description: Template contains the details used to build a replica virtual machine within the Machine Pool
                 properties:
                   acceleratedNetworking:
                     description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
@@ -8043,21 +7218,6 @@ spec:
                           description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
                           format: int32
                           type: integer
-                        managedDisk:
-                          description: ManagedDisk defines the managed disk options for a VM.
-                          properties:
-                            diskEncryptionSet:
-                              description: DiskEncryptionSetParameters defines disk encryption options.
-                              properties:
-                                id:
-                                  description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                  type: string
-                              type: object
-                            storageAccountType:
-                              type: string
-                          required:
-                          - storageAccountType
-                          type: object
                         nameSuffix:
                           description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
                           type: string
@@ -8222,7 +7382,7 @@ spec:
             - template
             type: object
           status:
-            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool.
+            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureMachinePool.
@@ -8262,7 +7422,7 @@ spec:
               instances:
                 description: Instances is the VM instance status for each VM in the VMSS
                 items:
-                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
+                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS
                   properties:
                     instanceID:
                       description: InstanceID is the identification of the Machine Instance within the VMSS
@@ -8290,542 +7450,20 @@ spec:
                 description: LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the next reconciliation loop.
                 properties:
                   futureData:
-                    description: FutureData is the base64 url encoded json Azure AutoRest Future.
+                    description: FutureData is the base64 url encoded json Azure AutoRest Future
                     type: string
                   name:
-                    description: Name is the name of the Azure resource.
+                    description: Name is the name of the Azure resource
                     type: string
                   resourceGroup:
-                    description: ResourceGroup is the Azure resource group for the resource.
+                    description: ResourceGroup is the Azure resource group for the resource
                     type: string
                   type:
-                    description: Type describes the type of future, update, create, delete, etc.
+                    description: Type describes the type of future, update, create, delete, etc
                     type: string
                 required:
                 - type
                 type: object
-              provisioningState:
-                description: ProvisioningState is the provisioning state of the Azure virtual machine.
-                type: string
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-              replicas:
-                description: Replicas is the most recently observed number of replicas.
-                format: int32
-                type: integer
-              version:
-                description: Version is the Kubernetes version for the current VMSS model
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: AzureMachinePool replicas count
-      jsonPath: .status.replicas
-      name: Replicas
-      type: string
-    - description: AzureMachinePool replicas count
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: Azure VMSS provisioning state
-      jsonPath: .status.provisioningState
-      name: State
-      type: string
-    - description: Cluster to which this AzureMachinePool belongs
-      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
-      name: Cluster
-      priority: 1
-      type: string
-    - description: MachinePool object to which this AzureMachinePool belongs
-      jsonPath: .metadata.ownerReferences[?(@.kind=="MachinePool")].name
-      name: MachinePool
-      priority: 1
-      type: string
-    - description: Azure VMSS ID
-      jsonPath: .spec.providerID
-      name: VMSS ID
-      priority: 1
-      type: string
-    - description: Azure VM Size
-      jsonPath: .spec.template.vmSize
-      name: VM Size
-      priority: 1
-      type: string
-    name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureMachinePool is the Schema for the azuremachinepools API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool.
-            properties:
-              additionalTags:
-                additionalProperties:
-                  type: string
-                description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.
-                type: object
-              identity:
-                default: None
-                description: Identity is the type of identity used for the Virtual Machine Scale Set. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM
-                enum:
-                - None
-                - SystemAssigned
-                - UserAssigned
-                type: string
-              location:
-                description: Location is the Azure region location e.g. westus2
-                type: string
-              nodeDrainTimeout:
-                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
-                type: string
-              providerID:
-                description: ProviderID is the identification ID of the Virtual Machine Scale Set
-                type: string
-              providerIDList:
-                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
-                items:
-                  type: string
-                type: array
-              roleAssignmentName:
-                description: RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.
-                type: string
-              strategy:
-                default:
-                  rollingUpdate:
-                    deletePolicy: Oldest
-                    maxSurge: 1
-                    maxUnavailable: 0
-                  type: RollingUpdate
-                description: The deployment strategy to use to replace existing AzureMachinePoolMachines with new ones.
-                properties:
-                  rollingUpdate:
-                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
-                    properties:
-                      deletePolicy:
-                        default: Oldest
-                        description: DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are "Random, "Newest", "Oldest" When no value is supplied, the default is Oldest
-                        enum:
-                        - Random
-                        - Newest
-                        - Oldest
-                        type: string
-                      maxSurge:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        default: 1
-                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
-                        x-kubernetes-int-or-string: true
-                      maxUnavailable:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        default: 0
-                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
-                        x-kubernetes-int-or-string: true
-                    type: object
-                  type:
-                    default: RollingUpdate
-                    description: Type of deployment. Currently the only supported strategy is RollingUpdate
-                    enum:
-                    - RollingUpdate
-                    type: string
-                type: object
-              template:
-                description: Template contains the details used to build a replica virtual machine within the Machine Pool
-                properties:
-                  acceleratedNetworking:
-                    description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
-                    type: boolean
-                  dataDisks:
-                    description: DataDisks specifies the list of data disks to be created for a Virtual Machine
-                    items:
-                      description: DataDisk specifies the parameters that are used to add one or more data disks to the machine.
-                      properties:
-                        cachingType:
-                          description: CachingType specifies the caching requirements.
-                          enum:
-                          - None
-                          - ReadOnly
-                          - ReadWrite
-                          type: string
-                        diskSizeGB:
-                          description: DiskSizeGB is the size in GB to assign to the data disk.
-                          format: int32
-                          type: integer
-                        lun:
-                          description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
-                          format: int32
-                          type: integer
-                        managedDisk:
-                          description: ManagedDisk specifies the Managed Disk parameters for the data disk.
-                          properties:
-                            diskEncryptionSet:
-                              description: DiskEncryptionSetParameters defines disk encryption options.
-                              properties:
-                                id:
-                                  description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                  type: string
-                              type: object
-                            storageAccountType:
-                              type: string
-                          type: object
-                        nameSuffix:
-                          description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
-                          type: string
-                      required:
-                      - diskSizeGB
-                      - nameSuffix
-                      type: object
-                    type: array
-                  image:
-                    description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
-                    properties:
-                      id:
-                        description: ID specifies an image to use by ID
-                        type: string
-                      marketplace:
-                        description: Marketplace specifies an image to use from the Azure Marketplace
-                        properties:
-                          offer:
-                            description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
-                            minLength: 1
-                            type: string
-                          publisher:
-                            description: Publisher is the name of the organization that created the image
-                            minLength: 1
-                            type: string
-                          sku:
-                            description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
-                            minLength: 1
-                            type: string
-                          thirdPartyImage:
-                            default: false
-                            description: ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.
-                            type: boolean
-                          version:
-                            description: Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                            minLength: 1
-                            type: string
-                        required:
-                        - offer
-                        - publisher
-                        - sku
-                        - version
-                        type: object
-                      sharedGallery:
-                        description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
-                        properties:
-                          gallery:
-                            description: Gallery specifies the name of the shared image gallery that contains the image
-                            minLength: 1
-                            type: string
-                          name:
-                            description: Name is the name of the image
-                            minLength: 1
-                            type: string
-                          offer:
-                            description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                            type: string
-                          publisher:
-                            description: Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                            type: string
-                          resourceGroup:
-                            description: ResourceGroup specifies the resource group containing the shared image gallery
-                            minLength: 1
-                            type: string
-                          sku:
-                            description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                            type: string
-                          subscriptionID:
-                            description: SubscriptionID is the identifier of the subscription that contains the shared image gallery
-                            minLength: 1
-                            type: string
-                          version:
-                            description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                            minLength: 1
-                            type: string
-                        required:
-                        - gallery
-                        - name
-                        - resourceGroup
-                        - subscriptionID
-                        - version
-                        type: object
-                    type: object
-                  osDisk:
-                    description: OSDisk contains the operating system disk information for a Virtual Machine
-                    properties:
-                      cachingType:
-                        description: CachingType specifies the caching requirements.
-                        enum:
-                        - None
-                        - ReadOnly
-                        - ReadWrite
-                        type: string
-                      diffDiskSettings:
-                        description: DiffDiskSettings describe ephemeral disk settings for the os disk.
-                        properties:
-                          option:
-                            description: Option enables ephemeral OS when set to "Local" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details
-                            enum:
-                            - Local
-                            type: string
-                        required:
-                        - option
-                        type: object
-                      diskSizeGB:
-                        description: DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided
-                        format: int32
-                        type: integer
-                      managedDisk:
-                        description: ManagedDisk specifies the Managed Disk parameters for the OS disk.
-                        properties:
-                          diskEncryptionSet:
-                            description: DiskEncryptionSetParameters defines disk encryption options.
-                            properties:
-                              id:
-                                description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                type: string
-                            type: object
-                          storageAccountType:
-                            type: string
-                        type: object
-                      osType:
-                        type: string
-                    required:
-                    - osType
-                    type: object
-                  securityProfile:
-                    description: SecurityProfile specifies the Security profile settings for a virtual machine.
-                    properties:
-                      encryptionAtHost:
-                        description: This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.
-                        type: boolean
-                    type: object
-                  spotVMOptions:
-                    description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
-                    properties:
-                      maxPrice:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                    type: object
-                  sshPublicKey:
-                    description: SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine
-                    type: string
-                  subnetName:
-                    description: SubnetName selects the Subnet where the VMSS will be placed
-                    type: string
-                  terminateNotificationTimeout:
-                    description: TerminateNotificationTimeout enables or disables VMSS scheduled events termination notification with specified timeout allowed values are between 5 and 15 (mins)
-                    type: integer
-                  vmSize:
-                    description: VMSize is the size of the Virtual Machine to build. See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#virtualmachinesizetypes
-                    type: string
-                required:
-                - osDisk
-                - sshPublicKey
-                - vmSize
-                type: object
-              userAssignedIdentities:
-                description: UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachinePool. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli
-                items:
-                  description: UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.
-                  properties:
-                    providerID:
-                      description: 'ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: ''azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
-                      type: string
-                  required:
-                  - providerID
-                  type: object
-                type: array
-            required:
-            - location
-            - template
-            type: object
-          status:
-            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool.
-            properties:
-              conditions:
-                description: Conditions defines current service state of the AzureMachinePool.
-                items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                      type: string
-                    severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              failureMessage:
-                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output."
-                type: string
-              failureReason:
-                description: "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output."
-                type: string
-              image:
-                description: Image is the current image used in the AzureMachinePool. When the spec image is nil, this image is populated with the details of the defaulted Azure Marketplace "capi" offer.
-                properties:
-                  id:
-                    description: ID specifies an image to use by ID
-                    type: string
-                  marketplace:
-                    description: Marketplace specifies an image to use from the Azure Marketplace
-                    properties:
-                      offer:
-                        description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
-                        minLength: 1
-                        type: string
-                      publisher:
-                        description: Publisher is the name of the organization that created the image
-                        minLength: 1
-                        type: string
-                      sku:
-                        description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
-                        minLength: 1
-                        type: string
-                      thirdPartyImage:
-                        default: false
-                        description: ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.
-                        type: boolean
-                      version:
-                        description: Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                        minLength: 1
-                        type: string
-                    required:
-                    - offer
-                    - publisher
-                    - sku
-                    - version
-                    type: object
-                  sharedGallery:
-                    description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
-                    properties:
-                      gallery:
-                        description: Gallery specifies the name of the shared image gallery that contains the image
-                        minLength: 1
-                        type: string
-                      name:
-                        description: Name is the name of the image
-                        minLength: 1
-                        type: string
-                      offer:
-                        description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      publisher:
-                        description: Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      resourceGroup:
-                        description: ResourceGroup specifies the resource group containing the shared image gallery
-                        minLength: 1
-                        type: string
-                      sku:
-                        description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      subscriptionID:
-                        description: SubscriptionID is the identifier of the subscription that contains the shared image gallery
-                        minLength: 1
-                        type: string
-                      version:
-                        description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                        minLength: 1
-                        type: string
-                    required:
-                    - gallery
-                    - name
-                    - resourceGroup
-                    - subscriptionID
-                    - version
-                    type: object
-                type: object
-              instances:
-                description: Instances is the VM instance status for each VM in the VMSS
-                items:
-                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
-                  properties:
-                    instanceID:
-                      description: InstanceID is the identification of the Machine Instance within the VMSS
-                      type: string
-                    instanceName:
-                      description: InstanceName is the name of the Machine Instance within the VMSS
-                      type: string
-                    latestModelApplied:
-                      description: LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.
-                      type: boolean
-                    providerID:
-                      description: ProviderID is the provider identification of the VMSS Instance
-                      type: string
-                    provisioningState:
-                      description: ProvisioningState is the provisioning state of the Azure virtual machine instance.
-                      type: string
-                    version:
-                      description: Version defines the Kubernetes version for the VM Instance
-                      type: string
-                  required:
-                  - latestModelApplied
-                  type: object
-                type: array
-              longRunningOperationStates:
-                description: LongRunningOperationStates saves the state for Azure long-running operations so they can be continued on the next reconciliation loop.
-                items:
-                  description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
-                  properties:
-                    data:
-                      description: Data is the base64 url encoded json Azure AutoRest Future.
-                      type: string
-                    name:
-                      description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
-                      type: string
-                    resourceGroup:
-                      description: ResourceGroup is the Azure resource group for the resource.
-                      type: string
-                    serviceName:
-                      description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
-                      type: string
-                    type:
-                      description: Type describes the type of future, such as update, create, delete, etc.
-                      type: string
-                  required:
-                  - name
-                  - serviceName
-                  - type
-                  type: object
-                type: array
               provisioningState:
                 description: ProvisioningState is the provisioning state of the Azure virtual machine.
                 type: string
@@ -8857,11 +7495,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1alpha3: v1alpha3
   name: azuremachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -8874,6 +7512,130 @@ spec:
     singular: azuremachine
   scope: Namespaced
   versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AzureMachine is the Schema for the azuremachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureMachineSpec defines the desired state of AzureMachine
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.
+                type: object
+              allocatePublicIP:
+                description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
+                type: boolean
+              availabilityZone:
+                properties:
+                  enabled:
+                    type: boolean
+                  id:
+                    type: string
+                type: object
+              image:
+                description: 'Image defines information about the image to use for VM creation. There are three ways to specify an image: by ID, by publisher, or by Shared Image Gallery. If specifying an image by ID, only the ID field needs to be set. If specifying an image by publisher, the Publisher, Offer, SKU, and Version fields must be set. If specifying an image from a Shared Image Gallery, the SubscriptionID, ResourceGroup, Gallery, Name, and Version fields must be set.'
+                properties:
+                  gallery:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  offer:
+                    type: string
+                  publisher:
+                    type: string
+                  resourceGroup:
+                    type: string
+                  sku:
+                    type: string
+                  subscriptionID:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              location:
+                type: string
+              osDisk:
+                properties:
+                  diskSizeGB:
+                    format: int32
+                    type: integer
+                  managedDisk:
+                    properties:
+                      storageAccountType:
+                        type: string
+                    required:
+                    - storageAccountType
+                    type: object
+                  osType:
+                    type: string
+                required:
+                - diskSizeGB
+                - managedDisk
+                - osType
+                type: object
+              providerID:
+                description: ProviderID is the unique identifier as specified by the cloud provider.
+                type: string
+              sshPublicKey:
+                type: string
+              vmSize:
+                type: string
+            required:
+            - location
+            - osDisk
+            - sshPublicKey
+            - vmSize
+            type: object
+          status:
+            description: AzureMachineStatus defines the observed state of AzureMachine
+            properties:
+              addresses:
+                description: Addresses contains the Azure instance associated addresses.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
+                      type: string
+                    type:
+                      description: Node address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              errorMessage:
+                description: "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              errorReason:
+                description: "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              vmState:
+                description: VMState is the provisioning state of the Azure virtual machine.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
   - additionalPrinterColumns:
     - description: AzureMachine ready status
       jsonPath: .status.ready
@@ -8906,7 +7668,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureMachine is the Schema for the azuremachines API.
+        description: AzureMachine is the Schema for the azuremachines API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -8917,7 +7679,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineSpec defines the desired state of AzureMachine.
+            description: AzureMachineSpec defines the desired state of AzureMachine
             properties:
               acceleratedNetworking:
                 description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
@@ -8953,21 +7715,6 @@ spec:
                       description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
                       format: int32
                       type: integer
-                    managedDisk:
-                      description: ManagedDisk defines the managed disk options for a VM.
-                      properties:
-                        diskEncryptionSet:
-                          description: DiskEncryptionSetParameters defines disk encryption options.
-                          properties:
-                            id:
-                              description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                              type: string
-                          type: object
-                        storageAccountType:
-                          type: string
-                      required:
-                      - storageAccountType
-                      type: object
                     nameSuffix:
                       description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
                       type: string
@@ -9114,7 +7861,7 @@ spec:
                     type: boolean
                 type: object
               spotVMOptions:
-                description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM.
+                description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
                 properties:
                   maxPrice:
                     anyOf:
@@ -9147,7 +7894,7 @@ spec:
             - vmSize
             type: object
           status:
-            description: AzureMachineStatus defines the observed state of AzureMachine.
+            description: AzureMachineStatus defines the observed state of AzureMachine
             properties:
               addresses:
                 description: Addresses contains the Azure instance associated addresses.
@@ -9200,375 +7947,6 @@ spec:
               failureReason:
                 description: "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
                 type: string
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-              vmState:
-                description: VMState is the provisioning state of the Azure virtual machine.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: AzureMachine ready status
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: Azure VM provisioning state
-      jsonPath: .status.vmState
-      name: State
-      type: string
-    - description: Cluster to which this AzureMachine belongs
-      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
-      name: Cluster
-      priority: 1
-      type: string
-    - description: Machine object to which this AzureMachine belongs
-      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
-      name: Machine
-      priority: 1
-      type: string
-    - description: Azure VM ID
-      jsonPath: .spec.providerID
-      name: VM ID
-      priority: 1
-      type: string
-    - description: Azure VM Size
-      jsonPath: .spec.vmSize
-      name: VM Size
-      priority: 1
-      type: string
-    name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureMachine is the Schema for the azuremachines API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureMachineSpec defines the desired state of AzureMachine.
-            properties:
-              acceleratedNetworking:
-                description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
-                type: boolean
-              additionalTags:
-                additionalProperties:
-                  type: string
-                description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.
-                type: object
-              allocatePublicIP:
-                description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
-                type: boolean
-              dataDisks:
-                description: DataDisk specifies the parameters that are used to add one or more data disks to the machine
-                items:
-                  description: DataDisk specifies the parameters that are used to add one or more data disks to the machine.
-                  properties:
-                    cachingType:
-                      description: CachingType specifies the caching requirements.
-                      enum:
-                      - None
-                      - ReadOnly
-                      - ReadWrite
-                      type: string
-                    diskSizeGB:
-                      description: DiskSizeGB is the size in GB to assign to the data disk.
-                      format: int32
-                      type: integer
-                    lun:
-                      description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
-                      format: int32
-                      type: integer
-                    managedDisk:
-                      description: ManagedDisk specifies the Managed Disk parameters for the data disk.
-                      properties:
-                        diskEncryptionSet:
-                          description: DiskEncryptionSetParameters defines disk encryption options.
-                          properties:
-                            id:
-                              description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                              type: string
-                          type: object
-                        storageAccountType:
-                          type: string
-                      type: object
-                    nameSuffix:
-                      description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
-                      type: string
-                  required:
-                  - diskSizeGB
-                  - nameSuffix
-                  type: object
-                type: array
-              enableIPForwarding:
-                description: EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.
-                type: boolean
-              failureDomain:
-                description: FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone
-                type: string
-              identity:
-                default: None
-                description: Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM
-                enum:
-                - None
-                - SystemAssigned
-                - UserAssigned
-                type: string
-              image:
-                description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
-                properties:
-                  id:
-                    description: ID specifies an image to use by ID
-                    type: string
-                  marketplace:
-                    description: Marketplace specifies an image to use from the Azure Marketplace
-                    properties:
-                      offer:
-                        description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
-                        minLength: 1
-                        type: string
-                      publisher:
-                        description: Publisher is the name of the organization that created the image
-                        minLength: 1
-                        type: string
-                      sku:
-                        description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
-                        minLength: 1
-                        type: string
-                      thirdPartyImage:
-                        default: false
-                        description: ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.
-                        type: boolean
-                      version:
-                        description: Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                        minLength: 1
-                        type: string
-                    required:
-                    - offer
-                    - publisher
-                    - sku
-                    - version
-                    type: object
-                  sharedGallery:
-                    description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
-                    properties:
-                      gallery:
-                        description: Gallery specifies the name of the shared image gallery that contains the image
-                        minLength: 1
-                        type: string
-                      name:
-                        description: Name is the name of the image
-                        minLength: 1
-                        type: string
-                      offer:
-                        description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      publisher:
-                        description: Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      resourceGroup:
-                        description: ResourceGroup specifies the resource group containing the shared image gallery
-                        minLength: 1
-                        type: string
-                      sku:
-                        description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                        type: string
-                      subscriptionID:
-                        description: SubscriptionID is the identifier of the subscription that contains the shared image gallery
-                        minLength: 1
-                        type: string
-                      version:
-                        description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                        minLength: 1
-                        type: string
-                    required:
-                    - gallery
-                    - name
-                    - resourceGroup
-                    - subscriptionID
-                    - version
-                    type: object
-                type: object
-              osDisk:
-                description: OSDisk specifies the parameters for the operating system disk of the machine
-                properties:
-                  cachingType:
-                    description: CachingType specifies the caching requirements.
-                    enum:
-                    - None
-                    - ReadOnly
-                    - ReadWrite
-                    type: string
-                  diffDiskSettings:
-                    description: DiffDiskSettings describe ephemeral disk settings for the os disk.
-                    properties:
-                      option:
-                        description: Option enables ephemeral OS when set to "Local" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details
-                        enum:
-                        - Local
-                        type: string
-                    required:
-                    - option
-                    type: object
-                  diskSizeGB:
-                    description: DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided
-                    format: int32
-                    type: integer
-                  managedDisk:
-                    description: ManagedDisk specifies the Managed Disk parameters for the OS disk.
-                    properties:
-                      diskEncryptionSet:
-                        description: DiskEncryptionSetParameters defines disk encryption options.
-                        properties:
-                          id:
-                            description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                            type: string
-                        type: object
-                      storageAccountType:
-                        type: string
-                    type: object
-                  osType:
-                    type: string
-                required:
-                - osType
-                type: object
-              providerID:
-                description: ProviderID is the unique identifier as specified by the cloud provider.
-                type: string
-              roleAssignmentName:
-                description: RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.
-                type: string
-              securityProfile:
-                description: SecurityProfile specifies the Security profile settings for a virtual machine.
-                properties:
-                  encryptionAtHost:
-                    description: This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.
-                    type: boolean
-                type: object
-              spotVMOptions:
-                description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
-                properties:
-                  maxPrice:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              sshPublicKey:
-                type: string
-              subnetName:
-                description: SubnetName selects the Subnet where the VM will be placed
-                type: string
-              userAssignedIdentities:
-                description: UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli
-                items:
-                  description: UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.
-                  properties:
-                    providerID:
-                      description: 'ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: ''azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
-                      type: string
-                  required:
-                  - providerID
-                  type: object
-                type: array
-              vmSize:
-                type: string
-            required:
-            - osDisk
-            - sshPublicKey
-            - vmSize
-            type: object
-          status:
-            description: AzureMachineStatus defines the observed state of AzureMachine.
-            properties:
-              addresses:
-                description: Addresses contains the Azure instance associated addresses.
-                items:
-                  description: NodeAddress contains information for the node's address.
-                  properties:
-                    address:
-                      description: The node address.
-                      type: string
-                    type:
-                      description: Node address type, one of Hostname, ExternalIP or InternalIP.
-                      type: string
-                  required:
-                  - address
-                  - type
-                  type: object
-                type: array
-              conditions:
-                description: Conditions defines current service state of the AzureMachine.
-                items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                      type: string
-                    severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              failureMessage:
-                description: "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
-                type: string
-              failureReason:
-                description: "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
-                type: string
-              longRunningOperationStates:
-                description: LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.
-                items:
-                  description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
-                  properties:
-                    data:
-                      description: Data is the base64 url encoded json Azure AutoRest Future.
-                      type: string
-                    name:
-                      description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
-                      type: string
-                    resourceGroup:
-                      description: ResourceGroup is the Azure resource group for the resource.
-                      type: string
-                    serviceName:
-                      description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
-                      type: string
-                    type:
-                      description: Type describes the type of future, such as update, create, delete, etc.
-                      type: string
-                  required:
-                  - name
-                  - serviceName
-                  - type
-                  type: object
-                type: array
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
@@ -9593,11 +7971,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1alpha3: v1alpha3
   name: azuremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -9610,10 +7988,10 @@ spec:
     singular: azuremachinetemplate
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API.
+        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -9624,10 +8002,112 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
+            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
             properties:
               template:
-                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
+                description: AzureMachineTemplateResource describes the data needed to create am AzureMachine from a template
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior of the machine.
+                    properties:
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.
+                        type: object
+                      allocatePublicIP:
+                        description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
+                        type: boolean
+                      availabilityZone:
+                        properties:
+                          enabled:
+                            type: boolean
+                          id:
+                            type: string
+                        type: object
+                      image:
+                        description: 'Image defines information about the image to use for VM creation. There are three ways to specify an image: by ID, by publisher, or by Shared Image Gallery. If specifying an image by ID, only the ID field needs to be set. If specifying an image by publisher, the Publisher, Offer, SKU, and Version fields must be set. If specifying an image from a Shared Image Gallery, the SubscriptionID, ResourceGroup, Gallery, Name, and Version fields must be set.'
+                        properties:
+                          gallery:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          offer:
+                            type: string
+                          publisher:
+                            type: string
+                          resourceGroup:
+                            type: string
+                          sku:
+                            type: string
+                          subscriptionID:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      location:
+                        type: string
+                      osDisk:
+                        properties:
+                          diskSizeGB:
+                            format: int32
+                            type: integer
+                          managedDisk:
+                            properties:
+                              storageAccountType:
+                                type: string
+                            required:
+                            - storageAccountType
+                            type: object
+                          osType:
+                            type: string
+                        required:
+                        - diskSizeGB
+                        - managedDisk
+                        - osType
+                        type: object
+                      providerID:
+                        description: ProviderID is the unique identifier as specified by the cloud provider.
+                        type: string
+                      sshPublicKey:
+                        type: string
+                      vmSize:
+                        type: string
+                    required:
+                    - location
+                    - osDisk
+                    - sshPublicKey
+                    - vmSize
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
+            properties:
+              template:
+                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template
                 properties:
                   spec:
                     description: Spec is the specification of the desired behavior of the machine.
@@ -9666,21 +8146,6 @@ spec:
                               description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
                               format: int32
                               type: integer
-                            managedDisk:
-                              description: ManagedDisk defines the managed disk options for a VM.
-                              properties:
-                                diskEncryptionSet:
-                                  description: DiskEncryptionSetParameters defines disk encryption options.
-                                  properties:
-                                    id:
-                                      description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                      type: string
-                                  type: object
-                                storageAccountType:
-                                  type: string
-                              required:
-                              - storageAccountType
-                              type: object
                             nameSuffix:
                               description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
                               type: string
@@ -9827,7 +8292,7 @@ spec:
                             type: boolean
                         type: object
                       spotVMOptions:
-                        description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM.
+                        description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
                         properties:
                           maxPrice:
                             anyOf:
@@ -9867,269 +8332,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
-            properties:
-              template:
-                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
-                properties:
-                  spec:
-                    description: Spec is the specification of the desired behavior of the machine.
-                    properties:
-                      acceleratedNetworking:
-                        description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
-                        type: boolean
-                      additionalTags:
-                        additionalProperties:
-                          type: string
-                        description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.
-                        type: object
-                      allocatePublicIP:
-                        description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
-                        type: boolean
-                      dataDisks:
-                        description: DataDisk specifies the parameters that are used to add one or more data disks to the machine
-                        items:
-                          description: DataDisk specifies the parameters that are used to add one or more data disks to the machine.
-                          properties:
-                            cachingType:
-                              description: CachingType specifies the caching requirements.
-                              enum:
-                              - None
-                              - ReadOnly
-                              - ReadWrite
-                              type: string
-                            diskSizeGB:
-                              description: DiskSizeGB is the size in GB to assign to the data disk.
-                              format: int32
-                              type: integer
-                            lun:
-                              description: Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.
-                              format: int32
-                              type: integer
-                            managedDisk:
-                              description: ManagedDisk specifies the Managed Disk parameters for the data disk.
-                              properties:
-                                diskEncryptionSet:
-                                  description: DiskEncryptionSetParameters defines disk encryption options.
-                                  properties:
-                                    id:
-                                      description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                      type: string
-                                  type: object
-                                storageAccountType:
-                                  type: string
-                              type: object
-                            nameSuffix:
-                              description: NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.
-                              type: string
-                          required:
-                          - diskSizeGB
-                          - nameSuffix
-                          type: object
-                        type: array
-                      enableIPForwarding:
-                        description: EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.
-                        type: boolean
-                      failureDomain:
-                        description: FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone
-                        type: string
-                      identity:
-                        default: None
-                        description: Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM
-                        enum:
-                        - None
-                        - SystemAssigned
-                        - UserAssigned
-                        type: string
-                      image:
-                        description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
-                        properties:
-                          id:
-                            description: ID specifies an image to use by ID
-                            type: string
-                          marketplace:
-                            description: Marketplace specifies an image to use from the Azure Marketplace
-                            properties:
-                              offer:
-                                description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
-                                minLength: 1
-                                type: string
-                              publisher:
-                                description: Publisher is the name of the organization that created the image
-                                minLength: 1
-                                type: string
-                              sku:
-                                description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
-                                minLength: 1
-                                type: string
-                              thirdPartyImage:
-                                default: false
-                                description: ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.
-                                type: boolean
-                              version:
-                                description: Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                                minLength: 1
-                                type: string
-                            required:
-                            - offer
-                            - publisher
-                            - sku
-                            - version
-                            type: object
-                          sharedGallery:
-                            description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
-                            properties:
-                              gallery:
-                                description: Gallery specifies the name of the shared image gallery that contains the image
-                                minLength: 1
-                                type: string
-                              name:
-                                description: Name is the name of the image
-                                minLength: 1
-                                type: string
-                              offer:
-                                description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                                type: string
-                              publisher:
-                                description: Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                                type: string
-                              resourceGroup:
-                                description: ResourceGroup specifies the resource group containing the shared image gallery
-                                minLength: 1
-                                type: string
-                              sku:
-                                description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.
-                                type: string
-                              subscriptionID:
-                                description: SubscriptionID is the identifier of the subscription that contains the shared image gallery
-                                minLength: 1
-                                type: string
-                              version:
-                                description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
-                                minLength: 1
-                                type: string
-                            required:
-                            - gallery
-                            - name
-                            - resourceGroup
-                            - subscriptionID
-                            - version
-                            type: object
-                        type: object
-                      osDisk:
-                        description: OSDisk specifies the parameters for the operating system disk of the machine
-                        properties:
-                          cachingType:
-                            description: CachingType specifies the caching requirements.
-                            enum:
-                            - None
-                            - ReadOnly
-                            - ReadWrite
-                            type: string
-                          diffDiskSettings:
-                            description: DiffDiskSettings describe ephemeral disk settings for the os disk.
-                            properties:
-                              option:
-                                description: Option enables ephemeral OS when set to "Local" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details
-                                enum:
-                                - Local
-                                type: string
-                            required:
-                            - option
-                            type: object
-                          diskSizeGB:
-                            description: DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided
-                            format: int32
-                            type: integer
-                          managedDisk:
-                            description: ManagedDisk specifies the Managed Disk parameters for the OS disk.
-                            properties:
-                              diskEncryptionSet:
-                                description: DiskEncryptionSetParameters defines disk encryption options.
-                                properties:
-                                  id:
-                                    description: ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription
-                                    type: string
-                                type: object
-                              storageAccountType:
-                                type: string
-                            type: object
-                          osType:
-                            type: string
-                        required:
-                        - osType
-                        type: object
-                      providerID:
-                        description: ProviderID is the unique identifier as specified by the cloud provider.
-                        type: string
-                      roleAssignmentName:
-                        description: RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.
-                        type: string
-                      securityProfile:
-                        description: SecurityProfile specifies the Security profile settings for a virtual machine.
-                        properties:
-                          encryptionAtHost:
-                            description: This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.
-                            type: boolean
-                        type: object
-                      spotVMOptions:
-                        description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
-                        properties:
-                          maxPrice:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        type: object
-                      sshPublicKey:
-                        type: string
-                      subnetName:
-                        description: SubnetName selects the Subnet where the VM will be placed
-                        type: string
-                      userAssignedIdentities:
-                        description: UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli
-                        items:
-                          description: UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.
-                          properties:
-                            providerID:
-                              description: 'ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: ''azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
-                              type: string
-                          required:
-                          - providerID
-                          type: object
-                        type: array
-                      vmSize:
-                        type: string
-                    required:
-                    - osDisk
-                    - sshPublicKey
-                    - vmSize
-                    type: object
-                required:
-                - spec
-                type: object
-            required:
-            - template
-            type: object
-        type: object
-    served: true
     storage: true
 status:
   acceptedNames:
@@ -10143,14 +8345,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
-  name: azuremanagedclusters.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: azuremanagedclusters.exp.infrastructure.cluster.x-k8s.io
 spec:
-  group: infrastructure.cluster.x-k8s.io
+  group: exp.infrastructure.cluster.x-k8s.io
   names:
     categories:
     - cluster-api
@@ -10165,7 +8367,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedCluster is the Schema for the azuremanagedclusters API.
+        description: AzureManagedCluster is the Schema for the azuremanagedclusters API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -10176,7 +8378,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
+            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster
             properties:
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -10194,50 +8396,7 @@ spec:
                 type: object
             type: object
           status:
-            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
-            properties:
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureManagedCluster is the Schema for the azuremanagedclusters API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
-            properties:
-              controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    format: int32
-                    type: integer
-                required:
-                - host
-                - port
-                type: object
-            type: object
-          status:
-            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
+            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster
             properties:
               ready:
                 description: Ready is true when the provider resource is ready.
@@ -10260,14 +8419,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
-  name: azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: azuremanagedcontrolplanes.exp.infrastructure.cluster.x-k8s.io
 spec:
-  group: infrastructure.cluster.x-k8s.io
+  group: exp.infrastructure.cluster.x-k8s.io
   names:
     categories:
     - cluster-api
@@ -10282,7 +8441,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
+        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -10293,23 +8452,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
+            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane
             properties:
-              aadProfile:
-                description: AadProfile is Azure Active Directory configuration to integrate with AKS for aad authentication.
-                properties:
-                  adminGroupObjectIDs:
-                    description: AdminGroupObjectIDs - AAD group object IDs that will have admin role of the cluster.
-                    items:
-                      type: string
-                    type: array
-                  managed:
-                    description: Managed - Whether to enable managed AAD.
-                    type: boolean
-                required:
-                - adminGroupObjectIDs
-                - managed
-                type: object
               additionalTags:
                 additionalProperties:
                   type: string
@@ -10328,6 +8472,13 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              defaultPoolRef:
+                description: DefaultPoolRef is the specification for the default pool, without which an AKS cluster cannot be created.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
                 type: object
               dnsServiceIP:
                 description: DNSServiceIP is an IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.
@@ -10392,6 +8543,7 @@ spec:
                 - name
                 type: object
             required:
+            - defaultPoolRef
             - location
             - nodeResourceGroupName
             - resourceGroupName
@@ -10399,254 +8551,11 @@ spec:
             - version
             type: object
           status:
-            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
+            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane
             properties:
               initialized:
                 description: Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
                 type: boolean
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
-            properties:
-              aadProfile:
-                description: AadProfile is Azure Active Directory configuration to integrate with AKS for aad authentication.
-                properties:
-                  adminGroupObjectIDs:
-                    description: AdminGroupObjectIDs - AAD group object IDs that will have admin role of the cluster.
-                    items:
-                      type: string
-                    type: array
-                  managed:
-                    description: Managed - Whether to enable managed AAD.
-                    type: boolean
-                required:
-                - adminGroupObjectIDs
-                - managed
-                type: object
-              additionalTags:
-                additionalProperties:
-                  type: string
-                description: AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.
-                type: object
-              apiServerAccessProfile:
-                description: APIServerAccessProfile is the access profile for AKS API server.
-                properties:
-                  authorizedIPRanges:
-                    description: AuthorizedIPRanges - Authorized IP Ranges to kubernetes API server.
-                    items:
-                      type: string
-                    type: array
-                  enablePrivateCluster:
-                    description: EnablePrivateCluster - Whether to create the cluster as a private cluster or not.
-                    type: boolean
-                  enablePrivateClusterPublicFQDN:
-                    description: EnablePrivateClusterPublicFQDN - Whether to create additional public FQDN for private cluster or not.
-                    type: boolean
-                  privateDNSZone:
-                    description: PrivateDNSZone - Private dns zone mode for private cluster.
-                    enum:
-                    - System
-                    - None
-                    type: string
-                type: object
-              controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    format: int32
-                    type: integer
-                required:
-                - host
-                - port
-                type: object
-              dnsServiceIP:
-                description: DNSServiceIP is an IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.
-                type: string
-              identityRef:
-                description: IdentityRef is a reference to a AzureClusterIdentity to be used when reconciling this cluster
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              loadBalancerProfile:
-                description: LoadBalancerProfile is the profile of the cluster load balancer.
-                properties:
-                  allocatedOutboundPorts:
-                    description: AllocatedOutboundPorts - Desired number of allocated SNAT ports per VM. Allowed values must be in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.
-                    format: int32
-                    type: integer
-                  idleTimeoutInMinutes:
-                    description: IdleTimeoutInMinutes - Desired outbound flow idle timeout in minutes. Allowed values must be in the range of 4 to 120 (inclusive). The default value is 30 minutes.
-                    format: int32
-                    type: integer
-                  managedOutboundIPs:
-                    description: ManagedOutboundIPs - Desired managed outbound IPs for the cluster load balancer.
-                    format: int32
-                    type: integer
-                  outboundIPPrefixes:
-                    description: OutboundIPPrefixes - Desired outbound IP Prefix resources for the cluster load balancer.
-                    items:
-                      type: string
-                    type: array
-                  outboundIPs:
-                    description: OutboundIPs - Desired outbound IP resources for the cluster load balancer.
-                    items:
-                      type: string
-                    type: array
-                type: object
-              loadBalancerSKU:
-                description: LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.
-                enum:
-                - Basic
-                - Standard
-                type: string
-              location:
-                description: 'Location is a string matching one of the canonical Azure region names. Examples: "westus2", "eastus".'
-                type: string
-              networkPlugin:
-                description: NetworkPlugin used for building Kubernetes network.
-                enum:
-                - azure
-                - kubenet
-                type: string
-              networkPolicy:
-                description: NetworkPolicy used for building Kubernetes network.
-                enum:
-                - azure
-                - calico
-                type: string
-              nodeResourceGroupName:
-                description: NodeResourceGroupName is the name of the resource group containining cluster IaaS resources. Will be populated to default in webhook.
-                type: string
-              resourceGroupName:
-                description: ResourceGroupName is the name of the Azure resource group for this AKS Cluster.
-                type: string
-              sku:
-                description: SKU is the SKU of the AKS to be provisioned.
-                properties:
-                  tier:
-                    description: Tier - Tier of a managed cluster SKU.
-                    enum:
-                    - Free
-                    - Paid
-                    type: string
-                required:
-                - tier
-                type: object
-              sshPublicKey:
-                description: SSHPublicKey is a string literal containing an ssh public key base64 encoded.
-                type: string
-              subscriptionID:
-                description: SubscriptionID is the GUID of the Azure subscription to hold this cluster.
-                type: string
-              version:
-                description: Version defines the desired Kubernetes version.
-                minLength: 2
-                type: string
-              virtualNetwork:
-                description: VirtualNetwork describes the vnet for the AKS cluster. Will be created if it does not exist.
-                properties:
-                  cidrBlock:
-                    type: string
-                  name:
-                    type: string
-                  subnet:
-                    description: ManagedControlPlaneSubnet describes a subnet for an AKS cluster.
-                    properties:
-                      cidrBlock:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - cidrBlock
-                    - name
-                    type: object
-                required:
-                - cidrBlock
-                - name
-                type: object
-            required:
-            - location
-            - resourceGroupName
-            - sshPublicKey
-            - version
-            type: object
-          status:
-            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
-            properties:
-              initialized:
-                description: Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
-                type: boolean
-              longRunningOperationStates:
-                description: LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.
-                items:
-                  description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
-                  properties:
-                    data:
-                      description: Data is the base64 url encoded json Azure AutoRest Future.
-                      type: string
-                    name:
-                      description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
-                      type: string
-                    resourceGroup:
-                      description: ResourceGroup is the Azure resource group for the resource.
-                      type: string
-                    serviceName:
-                      description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
-                      type: string
-                    type:
-                      description: Type describes the type of future, such as update, create, delete, etc.
-                      type: string
-                  required:
-                  - name
-                  - serviceName
-                  - type
-                  type: object
-                type: array
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
@@ -10668,14 +8577,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
-    cluster.x-k8s.io/v1alpha4: v1alpha4
-  name: azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+  name: azuremanagedmachinepools.exp.infrastructure.cluster.x-k8s.io
 spec:
-  group: infrastructure.cluster.x-k8s.io
+  group: exp.infrastructure.cluster.x-k8s.io
   names:
     categories:
     - cluster-api
@@ -10690,7 +8599,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
+        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -10701,14 +8610,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
+            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
             properties:
-              mode:
-                description: 'Mode - represents mode of an agent pool. Possible values include: System, User.'
-                enum:
-                - System
-                - User
-                type: string
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
                 format: int32
@@ -10722,71 +8625,10 @@ spec:
                 description: SKU is the size of the VMs in the node pool.
                 type: string
             required:
-            - mode
             - sku
             type: object
           status:
-            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
-            properties:
-              errorMessage:
-                description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
-                type: string
-              errorReason:
-                description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
-                type: string
-              ready:
-                description: Ready is true when the provider resource is ready.
-                type: boolean
-              replicas:
-                description: Replicas is the most recently observed number of replicas.
-                format: int32
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - name: v1alpha4
-    schema:
-      openAPIV3Schema:
-        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
-            properties:
-              mode:
-                description: 'Mode - represents mode of an agent pool. Possible values include: System, User.'
-                enum:
-                - System
-                - User
-                type: string
-              osDiskSizeGB:
-                description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-                format: int32
-                type: integer
-              providerIDList:
-                description: ProviderIDList is the unique identifier as specified by the cloud provider.
-                items:
-                  type: string
-                type: array
-              sku:
-                description: SKU is the size of the VMs in the node pool.
-                type: string
-            required:
-            - mode
-            - sku
-            type: object
-          status:
-            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
+            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool
             properties:
               errorMessage:
                 description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
@@ -10807,67 +8649,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    api-approved.kubernetes.io: unapproved
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-azure
-  name: azurepodidentityexceptions.aadpodidentity.k8s.io
-spec:
-  group: aadpodidentity.k8s.io
-  names:
-    kind: AzurePodIdentityException
-    listKind: AzurePodIdentityExceptionList
-    plural: azurepodidentityexceptions
-    singular: azurepodidentityexception
-  scope: Namespaced
-  versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: AzurePodIdentityException contains the pod selectors for all pods that don't require NMI to process and request token on their behalf.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzurePodIdentityExceptionSpec matches pods with the selector defined. If request originates from a pod that matches the selector, nmi will proxy the request and send response back without any validation.
-            properties:
-              metadata:
-                type: object
-              podLabels:
-                additionalProperties:
-                  type: string
-                type: object
-            type: object
-          status:
-            description: AzurePodIdentityExceptionStatus contains the status of an AzurePodIdentityException.
-            properties:
-              metadata:
-                type: object
-              status:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
The experimental types like `MachinePool` and `AzureMachinePool` got moved to a different api group on 0.5.x, so we need 0.4.x.

## Checklist

- [ ] Consider SIG UX feedback.
- [ ] Update changelog in CHANGELOG.md.
