### PR TITLE
Assign organizations.security.giantswarm.io CRD to Rainbow

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -313,7 +313,7 @@ crds:
       - workloadcluster
   organizations.security.giantswarm.io:
     owner:
-      - https://github.com/orgs/giantswarm/teams/team-biscuit
+      - https://github.com/orgs/giantswarm/teams/team-rainbow
     topics:
       - managementcluster
   releasecycles.release.giantswarm.io:


### PR DESCRIPTION
This moves ownership of the organizations.security.giantswarm.io CRD from biscuit to rainbow.