### PR TITLE
Added Notice property to Release CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add OpenStack Cluster API provider CRDs.
 - Add support for aggregating CRDs from other repositories.
+- `Notice` property for Release CRDs.
 
 ## [3.37.0] - 2021-11-12
 

--- a/config/crd/release.giantswarm.io_releases.yaml
+++ b/config/crd/release.giantswarm.io_releases.yaml
@@ -130,6 +130,10 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              notice:
+                description: Notice outlines anything worth being aware of in this
+                  release.
+                type: string
               state:
                 description: 'State indicates the availability of the release: deprecated,
                   active, or wip.'

--- a/helm/crds-common/templates/giantswarm.yaml
+++ b/helm/crds-common/templates/giantswarm.yaml
@@ -1839,6 +1839,9 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              notice:
+                description: Notice outlines anything worth being aware of in this release.
+                type: string
               state:
                 description: 'State indicates the availability of the release: deprecated, active, or wip.'
                 pattern: ^(active|deprecated|wip|preview)$

--- a/pkg/apis/release/v1alpha1/release_types.go
+++ b/pkg/apis/release/v1alpha1/release_types.go
@@ -90,6 +90,10 @@ type ReleaseSpec struct {
 	// +kubebuilder:validation:Pattern=`^(active|deprecated|wip|preview)$`
 	// State indicates the availability of the release: deprecated, active, or wip.
 	State ReleaseState `json:"state"`
+
+	// +kubebuilder:validation:Optional
+	// Notice outlines anything worth being aware of in this release.
+	Notice string `json:"notice,omitempty"`
 }
 
 // +k8s:openapi-gen=true


### PR DESCRIPTION
Related issue: https://github.com/giantswarm/roadmap/issues/559

Notice field for use to indicate anything in the release to be aware of. 

e.g.

```
This is a preview release only intended to be used for testing. No support is offered at the moment.
```

## Checklist

- [x] Consider SIG UX feedback.
- [x] Update changelog in CHANGELOG.md.
