### PR TITLE
Bump go module major version to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump go module major version to v5.
+
 ### Added
 
 - Upgrade `etcdbackup` CRD.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/apiextensions/v4
+module github.com/giantswarm/apiextensions/v5
 
 go 1.17
 

--- a/hack/assets.go
+++ b/hack/assets.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/giantswarm/apiextensions/v4/pkg/crd"
+	"github.com/giantswarm/apiextensions/v5/pkg/crd"
 )
 
 var upstreamReleaseAssets = []crd.ReleaseAssetFileDefinition{

--- a/hack/build-charts.go
+++ b/hack/build-charts.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-github/v39/github"
 	"golang.org/x/oauth2"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/crd"
+	"github.com/giantswarm/apiextensions/v5/pkg/crd"
 )
 
 func main() {

--- a/hack/patches.go
+++ b/hack/patches.go
@@ -4,7 +4,7 @@ import (
 	"github.com/giantswarm/to"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/crd"
+	"github.com/giantswarm/apiextensions/v5/pkg/crd"
 )
 
 const (

--- a/pkg/apis/core/v1alpha1/cert_types.go
+++ b/pkg/apis/core/v1alpha1/cert_types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/core/v1alpha1/kvm_cluster_types.go
+++ b/pkg/apis/core/v1alpha1/kvm_cluster_types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/serialization"
+	"github.com/giantswarm/apiextensions/v5/pkg/serialization"
 )
 
 // +genclient

--- a/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_cluster_types.go
@@ -3,7 +3,7 @@ package v1alpha2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/aws_control_plane_types.go
@@ -3,7 +3,7 @@ package v1alpha2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha2/cluster.go
+++ b/pkg/apis/infrastructure/v1alpha2/cluster.go
@@ -5,9 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha2/g8s_control_plane_types.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha2/networkpool.go
+++ b/pkg/apis/infrastructure/v1alpha2/networkpool.go
@@ -3,9 +3,9 @@ package v1alpha2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 // +k8s:deepcopy-gen=false

--- a/pkg/apis/infrastructure/v1alpha2/nodepool.go
+++ b/pkg/apis/infrastructure/v1alpha2/nodepool.go
@@ -5,9 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 // +k8s:deepcopy-gen=false

--- a/pkg/apis/infrastructure/v1alpha3/aws_cluster_types.go
+++ b/pkg/apis/infrastructure/v1alpha3/aws_cluster_types.go
@@ -3,7 +3,7 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha3/aws_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha3/aws_control_plane_types.go
@@ -3,7 +3,7 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha3/cluster.go
+++ b/pkg/apis/infrastructure/v1alpha3/cluster.go
@@ -6,9 +6,9 @@ import (
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha3/g8s_control_plane_types.go
+++ b/pkg/apis/infrastructure/v1alpha3/g8s_control_plane_types.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/infrastructure/v1alpha3/networkpool.go
+++ b/pkg/apis/infrastructure/v1alpha3/networkpool.go
@@ -3,9 +3,9 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 // +k8s:deepcopy-gen=false

--- a/pkg/apis/infrastructure/v1alpha3/nodepool.go
+++ b/pkg/apis/infrastructure/v1alpha3/nodepool.go
@@ -6,9 +6,9 @@ import (
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v4/pkg/id"
-	"github.com/giantswarm/apiextensions/v4/pkg/label"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/id"
+	"github.com/giantswarm/apiextensions/v5/pkg/label"
 )
 
 // +k8s:deepcopy-gen=false

--- a/pkg/apis/provider/v1alpha1/aws_types.go
+++ b/pkg/apis/provider/v1alpha1/aws_types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v5/pkg/annotation"
 )
 
 const (

--- a/pkg/apis/provider/v1alpha1/kvm_types.go
+++ b/pkg/apis/provider/v1alpha1/kvm_types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/apiextensions/v4/pkg/serialization"
+	"github.com/giantswarm/apiextensions/v5/pkg/serialization"
 )
 
 // +genclient


### PR DESCRIPTION
I forgot to bump the go module version when releasing v5.


## Checklist

- [ ] Consider SIG UX feedback.
- [X] Update changelog in CHANGELOG.md.
